### PR TITLE
fix(settings): 修复“含有skippedDirs属性时使用include或者includes会导致报项目已存在错误”的问题

### DIFF
--- a/ihub-settings/src/main/groovy/pub/ihub/plugin/IHubIncludeSubprojectsExtension.groovy
+++ b/ihub-settings/src/main/groovy/pub/ihub/plugin/IHubIncludeSubprojectsExtension.groovy
@@ -41,8 +41,11 @@ class IHubIncludeSubprojectsExtension {
 	 */
 	void include(String projectPath, String namePrefix = settings.rootProject.name + '-', String nameSuffix = '') {
 		println 'include project -> ' + projectPath
-		settings.include ":$projectPath"
-		settings.project(":$projectPath").name = namePrefix + projectPath.split(':').last() + nameSuffix
+		def gradleProjectPath = ":$projectPath"
+		if (!settings.findProject(gradleProjectPath)) {
+			settings.include gradleProjectPath
+			settings.project(gradleProjectPath).name = namePrefix + projectPath.split(':').last() + nameSuffix
+		}
 	}
 
 	/**


### PR DESCRIPTION
[ Root Cause ]
如果存在skippedDirs属性，那么settings插件会遍历当前目录的所有子目录，只要不在skippedDirs中就会被include。
此时，如果在settings.gradle中使用include或者includes，就会报错。

[ Solution ]
由于无论include还是includes，最终都会调用IHubIncludeSubprojectsExtension.inlucde()，
所以在include方法中用settings.findProject()返回值来判定项目是否已经添加过即可。