### PR TITLE
➖ 移除jaxb默认依赖，可以配置“iHubJava.defaultDependencies=jaxb”手动依赖

### DIFF
--- a/docs/iHubJava.md
+++ b/docs/iHubJava.md
@@ -10,7 +10,7 @@
 
 | Extension | Description | Default | Ext | Prj | Sys | Env |
 | --------- | ----------- | ------- | --- | ------- | ------ | --- |
-| `defaultDependencies` | 默认依赖（“,”分割）[详见](iHubJava?id=默认依赖)，可以设置`false`关闭默认配置 | `jaxb`、`log` | ✔ | ✔ | ❌ | ❌ |
+| `defaultDependencies` | 默认依赖（“,”分割）[详见](iHubJava?id=默认依赖)，可以设置`false`关闭默认配置 | `log` | ✔ | ✔ | ❌ | ❌ |
 | `compatibility` | Java兼容性配置 | ❌ | ✔ | ✔ | ✔ | ❌ |
 | `gradleCompilationIncremental` | gradle增量编译 | `true` | ✔ | ✔ | ✔ | ❌ |
 

--- a/ihub-plugins/src/main/groovy/pub/ihub/plugin/java/IHubJavaExtension.groovy
+++ b/ihub-plugins/src/main/groovy/pub/ihub/plugin/java/IHubJavaExtension.groovy
@@ -39,7 +39,7 @@ class IHubJavaExtension implements IHubProjectExtensionAware {
      * 默认依赖（“,”分割）
      */
     @IHubProperty
-    String defaultDependencies = 'jaxb,log'
+    String defaultDependencies = 'log'
 
     /**
      * Java兼容性配置

--- a/ihub-plugins/src/main/groovy/pub/ihub/plugin/java/IHubJavaPlugin.groovy
+++ b/ihub-plugins/src/main/groovy/pub/ihub/plugin/java/IHubJavaPlugin.groovy
@@ -41,7 +41,7 @@ import static pub.ihub.plugin.IHubProjectPluginAware.EvaluateStage.BEFORE
 ])
 class IHubJavaPlugin extends IHubProjectPluginAware<IHubJavaExtension> {
 
-    private static final Map<String, Closure> DEFAULT_DEPENDENCIES_CONFIG = [
+    static final Map<String, Closure> DEFAULT_DEPENDENCIES_CONFIG = [
         // 添加jaxb运行时依赖
         jaxb     : { IHubBomExtension ext ->
             ext.excludeModules {

--- a/ihub-plugins/src/test/groovy/pub/ihub/plugin/IHubBasicPluginTest.groovy
+++ b/ihub-plugins/src/test/groovy/pub/ihub/plugin/IHubBasicPluginTest.groovy
@@ -21,6 +21,7 @@ import org.gradle.testfixtures.ProjectBuilder
 import spock.lang.Title
 
 import static org.gradle.api.initialization.Settings.DEFAULT_SETTINGS_FILE
+import static pub.ihub.plugin.java.IHubJavaPlugin.DEFAULT_DEPENDENCIES_CONFIG
 
 
 
@@ -186,7 +187,7 @@ iHub.repoIncludeGroupRegex=pub\\.ihub\\..*
                 }
             }
         """
-        propertiesFile << 'iHubJava.defaultDependencies=jaxb,log,mapstruct\n'
+        propertiesFile << "iHubJava.defaultDependencies=${DEFAULT_DEPENDENCIES_CONFIG.keySet().join(',')}\n"
 
         when: '构建项目'
         def result = gradleBuilder.build()


### PR DESCRIPTION
[![](https://www.codefactor.io/repository/github/ihub-pub/plugins/badge)](https://www.codefactor.io/repository/github/ihub-pub/plugins) [![](https://codecov.io/gh/ihub-pub/plugins/branch/main/graph/badge.svg?token=ZQ0WR3ZSWG)](https://codecov.io/gh/ihub-pub/plugins)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

