### PR TITLE
feat(groovy): 添加“是否启用Groovy 4”的开关

### DIFF
--- a/ihub-plugins/src/main/groovy/pub/ihub/plugin/IHubPluginsExtension.groovy
+++ b/ihub-plugins/src/main/groovy/pub/ihub/plugin/IHubPluginsExtension.groovy
@@ -105,6 +105,12 @@ class IHubPluginsExtension implements IHubProjectExtensionAware {
     @IHubProperty
     boolean compileGroovyAllModules = false
 
+    /**
+     * 是否启用Groovy 4
+     */
+    @IHubProperty
+    boolean enableGroovy4 = false
+
     //</editor-fold>
 
     //<editor-fold desc="其他扩展属性">

--- a/ihub-plugins/src/main/groovy/pub/ihub/plugin/groovy/IHubGroovyPlugin.groovy
+++ b/ihub-plugins/src/main/groovy/pub/ihub/plugin/groovy/IHubGroovyPlugin.groovy
@@ -45,7 +45,8 @@ class IHubGroovyPlugin extends IHubProjectPluginAware {
                     'groovy-sql',
                     'groovy-templates',
                     'groovy-xml',
-                ]).collect { "org.codehaus.groovy:$it" } as String[])
+                ]).collect { withExtension(IHubPluginsExtension).enableGroovy4 ?
+                        "org.apache.groovy:$it" : "org.codehaus.groovy:$it" } as String[])
             }
         }
     }

--- a/ihub-plugins/src/main/groovy/pub/ihub/plugin/groovy/IHubGroovyPlugin.groovy
+++ b/ihub-plugins/src/main/groovy/pub/ihub/plugin/groovy/IHubGroovyPlugin.groovy
@@ -45,8 +45,7 @@ class IHubGroovyPlugin extends IHubProjectPluginAware {
                     'groovy-sql',
                     'groovy-templates',
                     'groovy-xml',
-                ]).collect { withExtension(IHubPluginsExtension).enableGroovy4 ?
-                        "org.apache.groovy:$it" : "org.codehaus.groovy:$it" } as String[])
+                ]).collect { "${withExtension(IHubPluginsExtension).enableGroovy4 ? 'org.apache.groovy' : 'org.codehaus.groovy'}:$it" } as String[])
             }
         }
     }

--- a/ihub-plugins/src/test/groovy/pub/ihub/plugin/IHubBasicPluginTest.groovy
+++ b/ihub-plugins/src/test/groovy/pub/ihub/plugin/IHubBasicPluginTest.groovy
@@ -210,6 +210,15 @@ iHub.repoIncludeGroupRegex=pub\\.ihub\\..*
         then: '检查结果'
         result.output.contains '│ implementation                         │ org.codehaus.groovy:groovy-all                          │'
         result.output.contains 'BUILD SUCCESSFUL'
+
+        when: '启用Groovy 4选项开关'
+        propertiesFile << 'iHub.enableGroovy4=true\n'
+        propertiesFile << 'groovy.version=4.0.4\n'
+        result = gradleBuilder.build()
+
+        then: '检查结果'
+        result.output.contains '│ implementation                          │ org.apache.groovy:groovy-all                           │'
+        result.output.contains 'BUILD SUCCESSFUL'
     }
 
     def 'Java插件默认配置测试'() {


### PR DESCRIPTION
[![](https://www.codefactor.io/repository/github/ihub-pub/plugins/badge)](https://www.codefactor.io/repository/github/ihub-pub/plugins) [![](https://codecov.io/gh/ihub-pub/plugins/branch/main/graph/badge.svg?token=ZQ0WR3ZSWG)](https://codecov.io/gh/ihub-pub/plugins)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

由于**Groovy**归入**Apache**基金会，从4版本开始组件的组标识变更为`org.apache.groovy`。
所以添加此开关，用于区隔`4`与之前版本。

但是，我没找到控制版本的配置，我猜是引入`groovy`官方插件时自动控制的。