### PR TITLE
配合Groovy插件，需要同时禁用增量编译和注解处理器

### DIFF
--- a/ihub-java/src/main/groovy/pub/ihub/plugin/java/IHubJavaExtension.groovy
+++ b/ihub-java/src/main/groovy/pub/ihub/plugin/java/IHubJavaExtension.groovy
@@ -65,7 +65,7 @@ class IHubJavaExtension implements IHubProjectExtensionAware {
      * 编译扩展属性，多个参数用空格分隔，如：-parameters -Xlint:unchecked
      */
     @IHubProperty(type = [PROJECT, SYSTEM])
-    String complierArgs
+    String compilerArgs
 
     /**
      * JMolecules架构，可选类型：cqrs、layered、onion

--- a/ihub-java/src/main/groovy/pub/ihub/plugin/java/IHubJavaPlugin.groovy
+++ b/ihub-java/src/main/groovy/pub/ihub/plugin/java/IHubJavaPlugin.groovy
@@ -127,7 +127,7 @@ class IHubJavaPlugin extends IHubProjectPluginAware<IHubJavaExtension> {
                     it.targetCompatibility = version
                 }
                 it.options.encoding = ext.compileEncoding
-                it.options.incremental = ext.gradleCompilationIncremental
+                it.options.incremental = !hasPlugin(GroovyPlugin) && ext.gradleCompilationIncremental
                 it.options.compilerArgs += ext.compilerArgs.with { args ->
                     args ? args.tokenize() : []
                 }
@@ -147,8 +147,8 @@ class IHubJavaPlugin extends IHubProjectPluginAware<IHubJavaExtension> {
                     }
                 }
 
-                // Groovy增量编译与Java注释处理器不能同时使用
-                if (hasPlugin(GroovyPlugin) && ext.gradleCompilationIncremental) {
+                // Groovy与Java注释处理器不能同时使用
+                if (hasPlugin(GroovyPlugin)) {
                     it.dependencies.removeIf {
                         it.type == 'annotationProcessor'
                     }

--- a/ihub-java/src/main/groovy/pub/ihub/plugin/java/IHubJavaPlugin.groovy
+++ b/ihub-java/src/main/groovy/pub/ihub/plugin/java/IHubJavaPlugin.groovy
@@ -128,7 +128,7 @@ class IHubJavaPlugin extends IHubProjectPluginAware<IHubJavaExtension> {
                 }
                 it.options.encoding = ext.compileEncoding
                 it.options.incremental = ext.gradleCompilationIncremental
-                it.options.compilerArgs += ext.complierArgs.with { args ->
+                it.options.compilerArgs += ext.compilerArgs.with { args ->
                     args ? args.tokenize() : []
                 }
             }

--- a/ihub-java/src/test/groovy/pub/ihub/plugin/java/IHubJavaPluginTest.groovy
+++ b/ihub-java/src/test/groovy/pub/ihub/plugin/java/IHubJavaPluginTest.groovy
@@ -89,7 +89,7 @@ class IHubJavaPluginTest extends IHubSpecification {
         propertiesFile << 'iHubJava.compatibility=8\n'
         propertiesFile << 'iHubJava.defaultDependencies=false\n'
         propertiesFile << 'iHubJava.applyOpenapiPlugin=true\n'
-        propertiesFile << 'iHubJava.complierArgs=-proc:none -nowarn\n'
+        propertiesFile << 'iHubJava.compilerArgs=-proc:none -nowarn\n'
 
         when: '构建项目'
         def result = gradleBuilder.build()

--- a/ihub-java/src/test/groovy/pub/ihub/plugin/java/IHubJavaPluginTest.groovy
+++ b/ihub-java/src/test/groovy/pub/ihub/plugin/java/IHubJavaPluginTest.groovy
@@ -165,8 +165,8 @@ class IHubJavaPluginTest extends IHubSpecification {
         then: '检查结果'
         result.output.contains 'BUILD SUCCESSFUL'
 
-        when: '禁用增量编译'
-        result = gradleBuilder.withArguments('-DiHubJava.gradleCompilationIncremental=false').build()
+        when: '启用增量编译'
+        result = gradleBuilder.withArguments('-DiHubJava.gradleCompilationIncremental=true').build()
 
         then: '检查结果'
         result.output.contains 'BUILD SUCCESSFUL'


### PR DESCRIPTION
[![](https://www.codefactor.io/repository/github/ihub-pub/plugins/badge)](https://www.codefactor.io/repository/github/ihub-pub/plugins) [![](https://codecov.io/gh/ihub-pub/plugins/branch/main/graph/badge.svg?token=ZQ0WR3ZSWG)](https://codecov.io/gh/ihub-pub/plugins)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

如题。

在实际使用过程中，Groovy插件和上面提到的两个开关就是此关系，这也是之前提出 #392 的原因，用来指定`-proc:none`编译选项。

但其实只要在Java插件中调整对启用Groovy插件之后的上述两个开关值即可，从而简化绝大多数Groovy项目的配置。