### PR TITLE
feat(java): 为Java型任务添加传入Jvm Options的参数

### DIFF
--- a/docs/advanced/multiAdvanced.md
+++ b/docs/advanced/multiAdvanced.md
@@ -12,7 +12,7 @@
 
 ```groovy
 plugins {
-    id 'pub.ihub.plugin.ihub-settings' version '1.3.1'
+    id 'pub.ihub.plugin.ihub-settings' version '1.3.2'
 }
 
 iHubSettings {

--- a/docs/iHubJava.md
+++ b/docs/iHubJava.md
@@ -25,6 +25,7 @@
 | `compatibility` | Java兼容性配置   | ❌ | ✔ | ✔ | ❌ | ❌ |
 | `gradleCompilationIncremental` | gradle增量编译  | `true` | ✔ | ✔ | ❌ | ❌ |
 | `compilerArgs` | 编译扩展属性，多个参数用空格分隔，如：-parameters -Xlint:unchecked  | ❌ | ✔ | ✔ | ❌ | ❌ |
+| `jvmArgs` | JVM扩展属性，多个参数用空格分隔，如：-XX:+UseG1GC -Xms128m -Xmx512m  | ❌ | ✔ | ✔ | ❌ | ❌ |
 | `applyOpenapiPlugin` | 启用 [SpringDoc](https://github.com/springdoc/springdoc-openapi-gradle-plugin) 插件  | `false` | ✔ | ✔ | ✔ | ❌ |
 | `jmoleculesArchitecture` | JMolecules架构（可选类型：cqrs、layered、onion）[详见](https://jmolecules.org) | `onion` | ✔ | ✔ | ❌ | ❌ |
 

--- a/docs/iHubSettings.md
+++ b/docs/iHubSettings.md
@@ -146,7 +146,7 @@ iHubSettings {
 | Plugin                      | Version                                                              |
 |-----------------------------|----------------------------------------------------------------------|
 | `com.gradle.plugin-publish` | [1.2.0](https://plugins.gradle.org/plugin/com.gradle.plugin-publish) |
-| `pub.ihub.plugin.*`         | [1.3.1](https://plugins.gradle.org/plugin/pub.ihub.plugin)           |
+| `pub.ihub.plugin.*`         | [1.3.2](https://plugins.gradle.org/plugin/pub.ihub.plugin)           |
 
 使用插件时可以不用加版本号，配置如下：
 

--- a/docs/snippet/gradle-wrapper.properties.md
+++ b/docs/snippet/gradle-wrapper.properties.md
@@ -1,3 +1,3 @@
 ```properties
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
 ```

--- a/docs/snippet/setting.gradle.md
+++ b/docs/snippet/setting.gradle.md
@@ -4,7 +4,7 @@
 
 ```kotlin
 plugins {
-    id("pub.ihub.plugin.ihub-settings") version "1.3.1"
+    id("pub.ihub.plugin.ihub-settings") version "1.3.2"
 }
 ```
 
@@ -12,7 +12,7 @@ plugins {
 
 ```groovy
 plugins {
-    id 'pub.ihub.plugin.ihub-settings' version '1.3.1'
+    id 'pub.ihub.plugin.ihub-settings' version '1.3.2'
 }
 ```
 

--- a/ihub-java/src/main/groovy/pub/ihub/plugin/java/IHubJavaExtension.groovy
+++ b/ihub-java/src/main/groovy/pub/ihub/plugin/java/IHubJavaExtension.groovy
@@ -68,6 +68,12 @@ class IHubJavaExtension extends IHubProjectExtensionAware {
     Property<String> compilerArgs
 
     /**
+     * JVM扩展属性，多个参数用空格分隔，如：-XX:+UseG1GC -Xms128m -Xmx512m
+     */
+    @IHubProperty
+    Property<String> jvmArgs
+
+    /**
      * JMolecules架构，可选类型：cqrs、layered、onion
      */
     @IHubProperty
@@ -86,6 +92,7 @@ class IHubJavaExtension extends IHubProjectExtensionAware {
         compatibility = objectFactory.property(String)
         gradleCompilationIncremental = objectFactory.property(Boolean).convention(true)
         compilerArgs = objectFactory.property(String)
+        jvmArgs = objectFactory.property(String)
         jmoleculesArchitecture = objectFactory.property(String).convention('onion')
         applyOpenapiPlugin = objectFactory.property(Boolean).convention(false)
     }

--- a/ihub-java/src/main/groovy/pub/ihub/plugin/java/IHubJavaPlugin.groovy
+++ b/ihub-java/src/main/groovy/pub/ihub/plugin/java/IHubJavaPlugin.groovy
@@ -27,6 +27,7 @@ import org.gradle.api.plugins.JavaLibraryPlugin
 import org.gradle.api.plugins.JavaPlugin
 import org.gradle.api.plugins.ProjectReportsPlugin
 import org.gradle.api.reporting.plugins.BuildDashboardPlugin
+import org.gradle.api.tasks.JavaExec
 import org.gradle.api.tasks.bundling.Jar
 import org.gradle.api.tasks.compile.AbstractCompile
 import org.jmolecules.bytebuddy.JMoleculesPlugin
@@ -177,6 +178,12 @@ class IHubJavaPlugin extends IHubProjectPluginAware<IHubJavaExtension> {
 
             // 配置Jar属性
             withTask Jar, JAR_CONFIG.curry(project)
+
+            if (it.jvmArgs.present) {
+                withTask(JavaExec) { exec ->
+                    exec.jvmArgs it.jvmArgs.get().tokenize()
+                }
+            }
         }
 
         // 配置lombok.config

--- a/ihub-java/src/test/groovy/pub/ihub/plugin/java/IHubJavaPluginTest.groovy
+++ b/ihub-java/src/test/groovy/pub/ihub/plugin/java/IHubJavaPluginTest.groovy
@@ -111,6 +111,7 @@ class IHubJavaPluginTest extends IHubSpecification {
         propertiesFile << 'iHubJava.defaultDependencies=false\n'
         propertiesFile << 'iHubJava.applyOpenapiPlugin=true\n'
         propertiesFile << 'iHubJava.compilerArgs=-proc:none -nowarn\n'
+        propertiesFile << 'iHubJava.jvmArgs=-XX:+UseG1GC -Xms128m -Xmx512m\n'
 
         when: '构建项目'
         def result = gradleBuilder.build()

--- a/settings.gradle
+++ b/settings.gradle
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 plugins {
-    id 'pub.ihub.plugin.ihub-settings' version '1.3.1'
+    id 'pub.ihub.plugin.ihub-settings' version '1.3.2-rc1'
 }
 
 dependencyResolutionManagement {


### PR DESCRIPTION
[![](https://www.codefactor.io/repository/github/ihub-pub/plugins/badge)](https://www.codefactor.io/repository/github/ihub-pub/plugins) [![](https://codecov.io/gh/ihub-pub/plugins/branch/main/graph/badge.svg?token=ZQ0WR3ZSWG)](https://codecov.io/gh/ihub-pub/plugins)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

iHubJava插件添加jvmArgs扩展选项，会为`JavaExec`类型的任务追加`jvmArgs`配置，包含`boorRun`，`jvmArgs`暂未转义`ext.applicationDefaultJvmArgs`，相关issues参见 #423