### PR TITLE
fix(repo): 修正Gradle阿里云代理仓库配置

### DIFF
--- a/ihub-settings/src/main/groovy/pub/ihub/plugin/IHubSettingsPlugin.groovy
+++ b/ihub-settings/src/main/groovy/pub/ihub/plugin/IHubSettingsPlugin.groovy
@@ -102,6 +102,7 @@ class IHubSettingsPlugin implements Plugin<Settings> {
                     maven {
                         name 'AliYunGradle'
                         url 'https://maven.aliyun.com/repository/gradle-plugin'
+                        artifactUrls 'https://plugins.gradle.org/m2'
                     }
                 }
                 gradlePluginPortal()


### PR DESCRIPTION
[![](https://www.codefactor.io/repository/github/ihub-pub/plugins/badge)](https://www.codefactor.io/repository/github/ihub-pub/plugins) [![](https://codecov.io/gh/ihub-pub/plugins/branch/main/graph/badge.svg?token=ZQ0WR3ZSWG)](https://codecov.io/gh/ihub-pub/plugins)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

代理仓库存在同步不完整的情况，如：只同步了pom没同步jar，需要配置artifactUrls，指向gradle仓库地址