### PR TITLE
fix(publish): 修复仓库发布路径冲突问题

### DIFF
--- a/ihub-publish/src/main/groovy/pub/ihub/plugin/publish/IHubPublishPlugin.groovy
+++ b/ihub-publish/src/main/groovy/pub/ihub/plugin/publish/IHubPublishPlugin.groovy
@@ -56,8 +56,6 @@ import static io.freefair.gradle.util.GitUtil.isGithubActions
 @IHubPlugin(value = IHubPublishExtension, beforeApplyPlugins = [IHubBomPlugin, IHubPluginsPlugin, MavenPublishPlugin])
 class IHubPublishPlugin extends IHubProjectPluginAware<IHubPublishExtension> {
 
-    public static final String REPOS_BUNDLES = 'repos/bundles'
-
     @Override
     void apply() {
         afterEvaluate {
@@ -78,7 +76,6 @@ class IHubPublishPlugin extends IHubProjectPluginAware<IHubPublishExtension> {
             if (extension.publishMavenCentral.get()) {
                 applyPlugin MavenCentralPublishPlugin
                 withExtension(MavenCentralExtension) {
-                    it.repoDir.set project.layout.buildDirectory.dir(REPOS_BUNDLES)
                     it.authToken.set Base64.encoder.encodeToString((iHubExt.repoUsername.orNull + ':' + iHubExt.repoPassword.orNull).bytes)
                 }
                 withTask(PublishToCentralPortalTask) {
@@ -258,12 +255,7 @@ class IHubPublishPlugin extends IHubProjectPluginAware<IHubPublishExtension> {
 
     private void configMavenRepo(PublishingExtension ext, IHubPluginsExtension iHubExt) {
         String mavenUrl = release ? iHubExt.releaseRepoUrl.orNull : iHubExt.snapshotRepoUrl.orNull
-        if (extension.publishMavenCentral.get()) {
-            ext.repositories.maven {
-                name = 'Local'
-                url = project.layout.buildDirectory.dir(REPOS_BUNDLES)
-            }
-        } else if (mavenUrl) {
+        if (!extension.publishMavenCentral.get() && mavenUrl) {
             ext.repositories.maven {
                 url mavenUrl
                 allowInsecureProtocol iHubExt.repoAllowInsecureProtocol.get()


### PR DESCRIPTION
[![](https://www.codefactor.io/repository/github/ihub-pub/plugins/badge)](https://www.codefactor.io/repository/github/ihub-pub/plugins) [![](https://codecov.io/gh/ihub-pub/plugins/branch/main/graph/badge.svg?token=ZQ0WR3ZSWG)](https://codecov.io/gh/ihub-pub/plugins) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=ihub-pub&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

- 移除了 IHubPublishPlugin 中的 REPOS_BUNDLES 常量- 删除了 Maven Central 发布中的本地仓库配置
- 优化了 Maven 仓库发布配置，仅在不发布到 Maven Central 时使用自定义仓库 URL