### PR TITLE
build(ihub-publish): 移除 PublishToCentralPortalTask 相关配置

### DIFF
--- a/ihub-publish/src/main/groovy/pub/ihub/plugin/publish/IHubPublishPlugin.groovy
+++ b/ihub-publish/src/main/groovy/pub/ihub/plugin/publish/IHubPublishPlugin.groovy
@@ -31,7 +31,6 @@ import org.gradle.api.plugins.catalog.VersionCatalogPlugin
 import org.gradle.api.publish.PublishingExtension
 import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.api.publish.maven.plugins.MavenPublishPlugin
-import org.gradle.api.publish.plugins.PublishingPlugin
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.jvm.tasks.Jar
 import org.gradle.plugins.signing.SigningExtension
@@ -44,7 +43,6 @@ import pub.ihub.plugin.bom.IHubBomExtension
 import pub.ihub.plugin.bom.IHubBomPlugin
 import tech.yanand.gradle.mavenpublish.MavenCentralExtension
 import tech.yanand.gradle.mavenpublish.MavenCentralPublishPlugin
-import tech.yanand.gradle.mavenpublish.PublishToCentralPortalTask
 
 import static cn.hutool.http.HttpUtil.get
 import static io.freefair.gradle.util.GitUtil.isGithubActions
@@ -77,9 +75,6 @@ class IHubPublishPlugin extends IHubProjectPluginAware<IHubPublishExtension> {
                 applyPlugin MavenCentralPublishPlugin
                 withExtension(MavenCentralExtension) {
                     it.authToken.set Base64.encoder.encodeToString((iHubExt.repoUsername.orNull + ':' + iHubExt.repoPassword.orNull).bytes)
-                }
-                withTask(PublishToCentralPortalTask) {
-                    project.tasks.getByName(PublishingPlugin.PUBLISH_LIFECYCLE_TASK_NAME).finalizedBy it
                 }
             }
         }


### PR DESCRIPTION
[![](https://www.codefactor.io/repository/github/ihub-pub/plugins/badge)](https://www.codefactor.io/repository/github/ihub-pub/plugins) [![](https://codecov.io/gh/ihub-pub/plugins/branch/main/graph/badge.svg?token=ZQ0WR3ZSWG)](https://codecov.io/gh/ihub-pub/plugins) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=ihub-pub&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

- 删除了 IHubPublishPlugin.groovy 中与 PublishToCentralPortalTask 相关的配置
- 移除了与发布到中央仓库相关的任务配置