### PR TITLE
build: 更新 ihub-settings 插件版本并启用代码验证插件

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-//import pub.ihub.plugin.verification.IHubVerificationExtension
+import pub.ihub.plugin.verification.IHubVerificationExtension
 plugins {
     alias(ihub.plugins.root)
     alias(ihub.plugins.copyright)
@@ -37,8 +37,8 @@ subprojects {
     apply {
         plugin("groovy")
         plugin("pub.ihub.plugin.ihub-java")
-//        plugin("pub.ihub.plugin.ihub-test")
-//        plugin("pub.ihub.plugin.ihub-verification")
+        plugin("pub.ihub.plugin.ihub-test")
+        plugin("pub.ihub.plugin.ihub-verification")
         plugin("pub.ihub.plugin.ihub-publish")
         plugin("java-gradle-plugin")
         plugin("com.gradle.plugin-publish")
@@ -59,9 +59,9 @@ subprojects {
             group("com.athaydes").version("2.5.1-groovy-3.0")
         }
     }
-//    configure<IHubVerificationExtension> {
-//        codenarcVersion.set("3.3.0")
-//    }
+    configure<IHubVerificationExtension> {
+        codenarcVersion.set("3.3.0")
+    }
 
 //</editor-fold>
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -14,5 +14,5 @@
  * limitations under the License.
  */
 plugins {
-    id("pub.ihub.plugin.ihub-settings") version "1.7.5"
+    id("pub.ihub.plugin.ihub-settings") version "1.7.6-m2"
 }


### PR DESCRIPTION
[![](https://www.codefactor.io/repository/github/ihub-pub/plugins/badge)](https://www.codefactor.io/repository/github/ihub-pub/plugins) [![](https://codecov.io/gh/ihub-pub/plugins/branch/main/graph/badge.svg?token=ZQ0WR3ZSWG)](https://codecov.io/gh/ihub-pub/plugins) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=ihub-pub&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

- 将 ihub-settings插件版本从 1.7.5 升级到 1.7.6-m2
- 在 build.gradle.kts 中启用 ihub-test 和 ihub-verification插件
- 配置 IHubVerificationExtension，设置 codenarc 版本为 3.3.0