### PR TITLE
refactor(ihub-githooks): 更新 commitCheck 任务注册方式

### DIFF
--- a/ihub-githooks/src/main/groovy/pub/ihub/plugin/githooks/IHubGitHooksPlugin.groovy
+++ b/ihub-githooks/src/main/groovy/pub/ihub/plugin/githooks/IHubGitHooksPlugin.groovy
@@ -36,7 +36,7 @@ class IHubGitHooksPlugin extends IHubProjectPluginAware<IHubGitHooksExtension> {
             it.execute it.hooksPath.orNull, it.hooks.get()
         }
 
-        project.task('commitCheck') {
+        project.tasks.register('commitCheck') {
             it.group = 'ihub'
             String header
             Map footers


### PR DESCRIPTION
[![](https://www.codefactor.io/repository/github/ihub-pub/plugins/badge)](https://www.codefactor.io/repository/github/ihub-pub/plugins) [![](https://codecov.io/gh/ihub-pub/plugins/branch/main/graph/badge.svg?token=ZQ0WR3ZSWG)](https://codecov.io/gh/ihub-pub/plugins) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=ihub-pub&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

- 将 project.task('commitCheck') 替换为 project.tasks.register('commitCheck')
- 此修改提高了代码的可维护性和一致性，符合 Gradle 新版本的推荐用法