### PR TITLE
feat(skills): 新增ihub-skills插件支持AI技能文件自动安装

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ IHub 提供了丰富的插件生态，按功能可分为以下几类：
 | [`pub.ihub.plugin.ihub-copyright`](https://doc.ihub.pub/plugins/list/iHubCopyright) | Copyright | Project | IDEA 统一版权信息配置 |
 | [`pub.ihub.plugin.ihub-git-hooks`](https://doc.ihub.pub/plugins/list/iHubGitHooks) | GitHooks | Project | Git 钩子 (Hooks) 自动化配置 |
 | [`pub.ihub.plugin.ihub-node`](https://doc.ihub.pub/plugins/list/iHubNode) | Node.js | Project | Node.js 及 cnpm 运行支持 |
+| [`pub.ihub.plugin.ihub-skills`](https://doc.ihub.pub/plugins/list/iHubSkills) | Skills | Project | AI 技能文件自动安装（Claude Code / Copilot / OpenCode） |
 
 ## 🚀 快速开始 (Quick Start)
 
@@ -224,6 +225,7 @@ plugins/
 ├── ihub-githooks/          # Git Hooks 自动化插件
 ├── ihub-node/              # Node.js 插件
 ├── ihub-javaagent/         # Javaagent 插件
+├── ihub-skills/            # AI 技能文件自动安装插件
 ├── samples/                # 示例项目
 └── docs/                   # VuePress 文档站点
 ```

--- a/docs/list/iHubSettings.md
+++ b/docs/list/iHubSettings.md
@@ -198,4 +198,48 @@ dependencyResolutionManagement {
 - 本插件也会自动配置`gradle/libs/`目录下的其他`.versions.toml`文件，如：`myLibs.versions.toml`，一般使用标准配置即可
 - 支持基于`iHub.profile`属性配置，根据profile替换`libs.versions.toml`里的`versions`配置，配置文件路径`gradle/libs/profiles`，如：`gradle/libs/profiles/dev.versions.toml`
 
+## ihub 插件版本目录（ihub.plugins.*）
+
+`ihub-settings` 插件会在 `settings.gradle` 配置阶段自动注册一个名为 `ihub` 的版本目录，其中包含所有 IHub 插件的别名，版本与 `ihub-settings` 保持一致。
+
+**别名规则**：
+
+| 插件 ID | 版本目录别名 |
+|---------|------------|
+| `pub.ihub.plugin` | `ihub.plugins.root` |
+| `pub.ihub.plugin.ihub-<name>` | `ihub.plugins.<name>`（`-` 转 `.`） |
+
+**使用示例**：
+
+::: code-tabs#build
+
+@tab Kotlin
+
+```kotlin
+// build.gradle.kts
+plugins {
+    alias(ihub.plugins.root)         // pub.ihub.plugin
+    alias(ihub.plugins.java)         // pub.ihub.plugin.ihub-java
+    alias(ihub.plugins.boot)         // pub.ihub.plugin.ihub-boot
+    alias(ihub.plugins.skills)       // pub.ihub.plugin.ihub-skills
+    alias(ihub.plugins.git.hooks)    // pub.ihub.plugin.ihub-git-hooks
+    alias(ihub.plugins.verification) // pub.ihub.plugin.ihub-verification
+}
+```
+
+@tab Groovy
+
+```groovy
+// build.gradle
+plugins {
+    alias(ihub.plugins.root)
+    alias(ihub.plugins.java)
+    alias(ihub.plugins.skills)
+}
+```
+
+:::
+
+> **注意**：`ihub` 版本目录由 `ihub-settings` 插件自动注册，无需在 `settings.gradle` 的 `dependencyResolutionManagement.versionCatalogs` 块中手动声明。
+
 @include(../snippet/footnote.md)

--- a/docs/list/iHubSkills.md
+++ b/docs/list/iHubSkills.md
@@ -1,0 +1,93 @@
+# ihub-skills
+
+::: info 插件信息
+- `ihub-skills`插件用于自动安装 IHub AI 技能文件，使 AI 开发工具能够感知 IHub Plugins 的使用规范和最佳实践。
+- 当项目应用此插件后，会在构建时自动向项目目录写入 IHub 专属 AI 技能文件。
+:::
+
+| 插件ID | 插件名称 | 插件类型 | 扩展名称 |
+|-------|---------|--------|---------|
+| `pub.ihub.plugin.ihub-skills` | `IHub Skills插件` | `Project`[^Project] | `iHubSkills` |
+
+::: tip 支持的 AI 开发工具
+- **Claude Code**：在 `.claude/commands/` 写入斜杠命令技能文件
+  - `/ihub-diagnose` — 诊断 Gradle 构建问题
+  - `/ihub-configure` — 插件配置向导
+- **GitHub Copilot**：在 `.github/copilot-instructions.md` 写入使用规范
+- **OpenCode**：在 `AGENTS.md` 写入使用规范
+:::
+
+## 快速开始
+
+::: tip 推荐：通过版本目录别名引用
+当项目已应用 `pub.ihub.plugin.ihub-settings` 后，IHub 会自动注册 `ihub` 版本目录，所有插件均可通过 `ihub.plugins.*` 别名引用，无需手动指定版本：
+
+```kotlin
+// settings.gradle.kts
+plugins {
+    id("pub.ihub.plugin.ihub-settings") version "1.9.5"
+}
+
+// build.gradle.kts
+plugins {
+    alias(ihub.plugins.skills)  // 等价于 id("pub.ihub.plugin.ihub-skills")
+}
+```
+
+版本目录别名规则：`pub.ihub.plugin.ihub-<name>` → `ihub.plugins.<name>`（例：`ihub-skills` → `ihub.plugins.skills`）；`pub.ihub.plugin`（根插件）→ `ihub.plugins.root`。
+:::
+
+若不使用版本目录，也可直接声明插件 ID：
+
+```kotlin
+plugins {
+    id("pub.ihub.plugin.ihub-skills") version "1.9.5"
+}
+```
+
+执行任意构建（包括 `./gradlew help`）后，技能文件会自动写入项目目录。
+
+## 扩展属性
+
+| Extension | Description | Default | Ext[^Ext] | Prj[^Prj] | Sys[^Sys] | Env[^Env] |
+| --------- | ----------- | ------- | --- | --- | --- | --- |
+| `enabled` | 是否启用 AI 技能安装 | `true` | ✔ | ✔ | ✔ | ❌ |
+| `claudeEnabled` | 是否安装 Claude Code 技能 | `true` | ✔ | ✔ | ✔ | ❌ |
+| `copilotEnabled` | 是否安装 GitHub Copilot 技能 | `true` | ✔ | ✔ | ✔ | ❌ |
+| `openCodeEnabled` | 是否安装 OpenCode 技能 | `true` | ✔ | ✔ | ✔ | ❌ |
+| `claudeCommandsDir` | Claude Code commands 目录 | `{rootProject}/.claude/commands` | ✔ | ❌ | ❌ | ❌ |
+| `copilotInstructionsFile` | Copilot instructions 文件路径 | `{rootProject}/.github/copilot-instructions.md` | ✔ | ❌ | ❌ | ❌ |
+| `agentsMdFile` | OpenCode AGENTS.md 文件路径 | `{rootProject}/AGENTS.md` | ✔ | ❌ | ❌ | ❌ |
+
+## 示例配置
+
+### 禁用部分 AI 工具
+
+```kotlin
+iHubSkills {
+    copilotEnabled.set(false)   // 不安装 Copilot 技能
+    openCodeEnabled.set(false)  // 不安装 OpenCode 技能
+}
+```
+
+### 完全禁用
+
+```kotlin
+iHubSkills {
+    enabled.set(false)
+}
+```
+
+### 自定义 Claude commands 目录
+
+```kotlin
+iHubSkills {
+    claudeCommandsDir.set(layout.projectDirectory.dir("my-ai/commands"))
+}
+```
+
+[^Project]: Project插件
+[^Ext]: 支持扩展属性配置
+[^Prj]: 支持项目属性配置（`gradle.properties`）
+[^Sys]: 支持系统属性配置（`-DiHub.xxx=value`）
+[^Env]: 支持环境变量配置

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,7 +29,7 @@ johnrengelman-processes = { module = 'com.github.johnrengelman.processes:com.git
 spring-boot = { module = 'org.springframework.boot:spring-boot-gradle-plugin', version.ref = 'spring-boot' }
 spring-boot-bp = { module = 'org.springframework.boot:spring-boot-buildpack-platform', version.ref = 'spring-boot' }
 native = { module = 'org.graalvm.buildtools:native-gradle-plugin', version = '1.1.0' }
-kotlin = { module = 'org.jetbrains.kotlin:kotlin-gradle-plugin', version = '2.3.21' }
+kotlin = { module = 'org.jetbrains.kotlin:kotlin-gradle-plugin', version = '2.3.20' }
 toml = { module = 'org.tomlj:tomlj', version = '1.1.1' }
 
 jacoco = { module = 'org.jacoco:jacoco', version.ref = 'jacoco' }

--- a/ihub-skills/build.gradle.kts
+++ b/ihub-skills/build.gradle.kts
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2021-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+plugins {
+    id("ihub.module-conventions")
+    id("pub.ihub.plugin.ihub-groovy")
+    id("pub.ihub.plugin.ihub-test")
+    id("pub.ihub.plugin.ihub-verification")
+    id("pub.ihub.plugin.ihub-publish")
+}
+
+description = "IHub AI Skills Gradle Plugin"
+
+gradlePlugin {
+    plugins {
+        create("iHubSkills") {
+            id = "pub.ihub.plugin.ihub-skills"
+            displayName = "IHub Skills"
+            description = "IHub AI Skills Gradle Plugin - Auto-installs AI skills for Claude Code, GitHub Copilot and OpenCode"
+            implementationClass = "pub.ihub.plugin.skills.IHubSkillsPlugin"
+            tags.set(listOf("ihub", "ai", "skills", "claude", "copilot", "opencode"))
+        }
+    }
+}

--- a/ihub-skills/src/main/groovy/pub/ihub/plugin/skills/IHubSkillsExtension.groovy
+++ b/ihub-skills/src/main/groovy/pub/ihub/plugin/skills/IHubSkillsExtension.groovy
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2021-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package pub.ihub.plugin.skills
+
+import groovy.transform.CompileStatic
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Property
+
+import javax.inject.Inject
+
+/**
+ * IHub AI Skills 插件扩展，支持多种 AI 开发工具的技能文件配置。
+ *
+ * @author henry
+ */
+@CompileStatic
+class IHubSkillsExtension {
+
+    /**
+     * 是否启用 AI 技能安装（默认开启）
+     */
+    final Property<Boolean> enabled
+
+    /**
+     * 是否安装 Claude Code 技能（.claude/commands/）
+     */
+    final Property<Boolean> claudeEnabled
+
+    /**
+     * 是否安装 GitHub Copilot 技能（.github/copilot-instructions.md）
+     */
+    final Property<Boolean> copilotEnabled
+
+    /**
+     * 是否安装 OpenCode 技能（AGENTS.md）
+     */
+    final Property<Boolean> openCodeEnabled
+
+    /**
+     * Claude Code commands 目录（默认：{rootProject}/.claude/commands/）
+     */
+    final DirectoryProperty claudeCommandsDir
+
+    /**
+     * GitHub Copilot instructions 文件（默认：{rootProject}/.github/copilot-instructions.md）
+     */
+    final RegularFileProperty copilotInstructionsFile
+
+    /**
+     * OpenCode AGENTS.md 文件（默认：{rootProject}/AGENTS.md）
+     */
+    final RegularFileProperty agentsMdFile
+
+    @Inject
+    IHubSkillsExtension(ObjectFactory objects) {
+        enabled = objects.property(Boolean).convention(true)
+        claudeEnabled = objects.property(Boolean).convention(true)
+        copilotEnabled = objects.property(Boolean).convention(true)
+        openCodeEnabled = objects.property(Boolean).convention(true)
+        claudeCommandsDir = objects.directoryProperty()
+        copilotInstructionsFile = objects.fileProperty()
+        agentsMdFile = objects.fileProperty()
+    }
+
+}

--- a/ihub-skills/src/main/groovy/pub/ihub/plugin/skills/IHubSkillsPlugin.groovy
+++ b/ihub-skills/src/main/groovy/pub/ihub/plugin/skills/IHubSkillsPlugin.groovy
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2021-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package pub.ihub.plugin.skills
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.tasks.TaskProvider
+
+/**
+ * IHub AI Skills 插件
+ * 当项目应用此插件后，会在构建时自动向项目目录写入 IHub 专属 AI 技能文件，
+ * 使多种 AI 开发工具能够感知 IHub Plugins 的使用规范和最佳实践：
+ *
+ * - **Claude Code**：在 `.claude/commands/` 写入斜杠命令技能文件
+ *   - `/ihub-diagnose` — 诊断 Gradle 构建问题
+ *   - `/ihub-configure` — 插件配置向导
+ * - **GitHub Copilot**：在 `.github/copilot-instructions.md` 写入使用规范
+ * - **OpenCode**：在 `AGENTS.md` 写入使用规范
+ *
+ * ## 基本用法
+ *
+ * ```kotlin
+ * plugins {
+ *     id("pub.ihub.plugin.ihub-skills")
+ * }
+ * ```
+ *
+ * ## 自定义配置
+ *
+ * ```kotlin
+ * iHubSkills {
+ *     copilotEnabled.set(false)   // 不安装 Copilot 技能
+ *     openCodeEnabled.set(false)  // 不安装 OpenCode 技能
+ * }
+ * ```
+ *
+ * @author henry
+ */
+class IHubSkillsPlugin implements Plugin<Project> {
+
+    static final String EXTENSION_NAME = 'iHubSkills'
+    static final String TASK_GROUP = 'ihub'
+
+    @Override
+    void apply(Project project) {
+        Project rootProject = project.rootProject
+        IHubSkillsExtension ext = project.extensions.create(EXTENSION_NAME, IHubSkillsExtension)
+
+        // 设置默认目录（基于 rootProject layout）
+        ext.claudeCommandsDir.convention(
+            rootProject.layout.projectDirectory.dir('.claude/commands')
+        )
+        ext.copilotInstructionsFile.convention(
+            rootProject.layout.projectDirectory.file('.github/copilot-instructions.md')
+        )
+        ext.agentsMdFile.convention(
+            rootProject.layout.projectDirectory.file('AGENTS.md')
+        )
+
+        // 注册 Claude Code 技能安装任务
+        TaskProvider<IHubClaudeSetupTask> claudeTask = project.tasks.register(
+            'iHubClaudeSetup', IHubClaudeSetupTask) { IHubClaudeSetupTask task ->
+            task.group = TASK_GROUP
+            task.description = 'Install IHub AI skills to .claude/commands/ for Claude Code.'
+            task.commandsDir.set(ext.claudeCommandsDir)
+            task.skillEnabled.set(ext.enabled.zip(ext.claudeEnabled) { Boolean a, Boolean b -> a && b })
+        }
+
+        // 注册 GitHub Copilot 技能安装任务
+        TaskProvider<IHubCopilotSetupTask> copilotTask = project.tasks.register(
+            'iHubCopilotSetup', IHubCopilotSetupTask) { IHubCopilotSetupTask task ->
+            task.group = TASK_GROUP
+            task.description = 'Install IHub AI skills to .github/copilot-instructions.md for GitHub Copilot.'
+            task.instructionsFile.set(ext.copilotInstructionsFile)
+            task.skillEnabled.set(ext.enabled.zip(ext.copilotEnabled) { Boolean a, Boolean b -> a && b })
+        }
+
+        // 注册 OpenCode 技能安装任务
+        TaskProvider<IHubOpenCodeSetupTask> openCodeTask = project.tasks.register(
+            'iHubOpenCodeSetup', IHubOpenCodeSetupTask) { IHubOpenCodeSetupTask task ->
+            task.group = TASK_GROUP
+            task.description = 'Install IHub AI skills to AGENTS.md for OpenCode.'
+            task.agentsMdFile.set(ext.agentsMdFile)
+            task.skillEnabled.set(ext.enabled.zip(ext.openCodeEnabled) { Boolean a, Boolean b -> a && b })
+        }
+
+        // 挂载到 help 任务，确保任意构建都会触发安装（与 iHubGitHooksSetup 策略一致）
+        project.tasks.named('help') { task ->
+            task.dependsOn(claudeTask, copilotTask, openCodeTask)
+        }
+    }
+
+}

--- a/ihub-skills/src/main/groovy/pub/ihub/plugin/skills/IHubSkillsTasks.groovy
+++ b/ihub-skills/src/main/groovy/pub/ihub/plugin/skills/IHubSkillsTasks.groovy
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2021-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package pub.ihub.plugin.skills
+
+import groovy.transform.CompileStatic
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
+
+import java.nio.file.Files
+import java.nio.file.Path
+
+/**
+ * IHub Claude Code 技能安装任务
+ *
+ * 将打包在 JAR 资源中的 AI 技能文件（.md）复制到项目的 .claude/commands/ 目录，
+ * 使 Claude Code 能够感知并提供 /ihub-diagnose、/ihub-configure 等斜杠命令。
+ *
+ * @author henry
+ */
+@CompileStatic
+@DisableCachingByDefault(because = '写入用户本地 .claude 目录，不适合构建缓存')
+abstract class IHubClaudeSetupTask extends DefaultTask {
+
+    private static final List<String> SKILL_NAMES = ['ihub-diagnose', 'ihub-configure']
+    private static final String RESOURCE_PREFIX = '/META-INF/ihub/skills/claude/'
+
+    @OutputDirectory
+    @Optional
+    abstract DirectoryProperty getCommandsDir()
+
+    @Input
+    abstract Property<Boolean> getSkillEnabled()
+
+    @TaskAction
+    void setup() {
+        if (!skillEnabled.get()) {
+            logger.lifecycle 'IHub Skills: Claude skill installation is disabled, skipping.'
+            return
+        }
+        File dir = commandsDir.get().asFile
+        dir.mkdirs()
+        SKILL_NAMES.each { String name ->
+            URL resource = IHubClaudeSetupTask.getResource("${RESOURCE_PREFIX}${name}.md")
+            Path target = dir.toPath().resolve("${name}.md")
+            Files.write(target, resource.bytes)
+            logger.lifecycle "IHub Skills: installed Claude skill /${name}"
+        }
+    }
+
+}
+
+/**
+ * IHub GitHub Copilot 技能安装任务
+ *
+ * 将 IHub 使用知识写入 .github/copilot-instructions.md，
+ * 使 GitHub Copilot 能够感知 IHub Plugins 的最佳实践。
+ *
+ * @author henry
+ */
+@CompileStatic
+@DisableCachingByDefault(because = '写入用户本地 .github 目录，不适合构建缓存')
+abstract class IHubCopilotSetupTask extends DefaultTask {
+
+    private static final String RESOURCE_PATH = '/META-INF/ihub/skills/copilot-instructions.md'
+
+    @OutputFile
+    @Optional
+    abstract RegularFileProperty getInstructionsFile()
+
+    @Input
+    abstract Property<Boolean> getSkillEnabled()
+
+    @TaskAction
+    void setup() {
+        if (!skillEnabled.get()) {
+            logger.lifecycle 'IHub Skills: Copilot skill installation is disabled, skipping.'
+            return
+        }
+        File file = instructionsFile.get().asFile
+        file.parentFile.mkdirs()
+        URL resource = IHubCopilotSetupTask.getResource(RESOURCE_PATH)
+        Files.write(file.toPath(), resource.bytes)
+        logger.lifecycle 'IHub Skills: installed Copilot instructions'
+    }
+
+}
+
+/**
+ * IHub OpenCode 技能安装任务
+ *
+ * 将 IHub 使用知识写入项目根目录的 AGENTS.md，
+ * 使 OpenCode 能够感知 IHub Plugins 的最佳实践。
+ *
+ * @author henry
+ */
+@CompileStatic
+@DisableCachingByDefault(because = '写入用户本地 AGENTS.md，不适合构建缓存')
+abstract class IHubOpenCodeSetupTask extends DefaultTask {
+
+    private static final String RESOURCE_PATH = '/META-INF/ihub/skills/AGENTS.md'
+
+    @OutputFile
+    @Optional
+    abstract RegularFileProperty getAgentsMdFile()
+
+    @Input
+    abstract Property<Boolean> getSkillEnabled()
+
+    @TaskAction
+    void setup() {
+        if (!skillEnabled.get()) {
+            logger.lifecycle 'IHub Skills: OpenCode skill installation is disabled, skipping.'
+            return
+        }
+        File file = agentsMdFile.get().asFile
+        file.parentFile.mkdirs()
+        URL resource = IHubOpenCodeSetupTask.getResource(RESOURCE_PATH)
+        Files.write(file.toPath(), resource.bytes)
+        logger.lifecycle 'IHub Skills: installed OpenCode AGENTS.md'
+    }
+
+}

--- a/ihub-skills/src/main/resources/META-INF/ihub/skills/AGENTS.md
+++ b/ihub-skills/src/main/resources/META-INF/ihub/skills/AGENTS.md
@@ -1,0 +1,92 @@
+# IHub Plugins - Agent Instructions
+
+This project uses the `pub.ihub.plugin` suite of Gradle plugins. Follow these guidelines when helping with this codebase.
+
+## Quick Reference
+
+### Plugin Selection Guide
+
+| Need | Plugin to Use |
+|------|--------------|
+| Multi-project setup | `pub.ihub.plugin.ihub-settings` |
+| Java project | `pub.ihub.plugin.ihub-java` |
+| Groovy project | `pub.ihub.plugin.ihub-groovy` |
+| Kotlin project | `pub.ihub.plugin.ihub-kotlin` |
+| Spring Boot | `pub.ihub.plugin.ihub-boot` |
+| Code quality + coverage | `pub.ihub.plugin.ihub-verification` |
+| Maven Central publish | `pub.ihub.plugin.ihub-publish` |
+| Git commit conventions | `pub.ihub.plugin.ihub-git-hooks` |
+| AI tool integration | `pub.ihub.plugin.ihub-skills` |
+
+### Minimal settings.gradle.kts
+
+```kotlin
+plugins {
+    id("pub.ihub.plugin.ihub-settings") version "1.9.5"
+}
+```
+
+### Typical build.gradle.kts (Java + Spring Boot)
+
+```kotlin
+plugins {
+    id("pub.ihub.plugin")
+    id("pub.ihub.plugin.ihub-java")
+    id("pub.ihub.plugin.ihub-boot")
+    id("pub.ihub.plugin.ihub-test")
+    id("pub.ihub.plugin.ihub-verification")
+}
+```
+
+## Gradle API Rules
+
+**Never use deprecated APIs. Always prefer:**
+
+- `tasks.register()` over `tasks.create()`
+- `tasks.named()` over `tasks.getByName()`
+- `layout.buildDirectory` over `buildDir`
+- `ListProperty<T>` over `Property<List<T>>`
+- `DirectoryProperty` over `Property<File>` for directories
+- `RegularFileProperty` over `Property<File>` for files
+- `Provider.map()` over `afterEvaluate {}`
+
+## Dependency Management
+
+All versions **must** be in `gradle/libs.versions.toml`. Never hardcode versions in build scripts.
+
+## Property Configuration
+
+IHub properties follow this priority (highest to lowest):
+1. System property: `-DiHub.xxx=value`
+2. Environment variable: `IHUB_XXX=value`
+3. `gradle.properties`
+4. Plugin default value
+
+## Common Anti-Patterns to Avoid
+
+```groovy
+// ❌ Wrong
+tasks.create('myTask') { ... }
+def dir = buildDir
+Property<List<String>> items
+
+// ✅ Correct
+tasks.register('myTask') { ... }
+def dir = layout.buildDirectory
+ListProperty<String> items
+```
+
+## Useful Commands
+
+```bash
+./gradlew build              # Full build
+./gradlew test               # Run tests
+./gradlew check -x test      # Static analysis only
+./gradlew spotlessApply      # Fix code style
+./gradlew commitCheck        # Validate commit message
+```
+
+## Reference
+
+- Documentation: https://doc.ihub.pub/plugins/
+- Repository: https://github.com/ihub-pub/plugins

--- a/ihub-skills/src/main/resources/META-INF/ihub/skills/claude/ihub-configure.md
+++ b/ihub-skills/src/main/resources/META-INF/ihub/skills/claude/ihub-configure.md
@@ -1,0 +1,112 @@
+---
+description: 根据用户描述的技术栈（Java/Groovy/Kotlin/Spring Boot 等）推荐合适的 IHub Plugins 组合，并生成开箱即用的配置代码片段。当用户需要初始化新项目或向现有项目添加 IHub 插件时使用。
+---
+
+你是 IHub Plugins 专家，专注于帮助用户配置最适合其技术栈的插件组合。
+
+## 配置向导流程
+
+### 第一步：了解项目需求
+
+询问用户以下关键信息（如果用户没有提供）：
+
+1. **主要语言**：Java / Groovy / Kotlin（可多选）
+2. **框架**：Spring Boot / 原生 Gradle 库
+3. **是否需要**：
+   - 代码质量检查（CodeNarc / PMD）
+   - 测试覆盖率（JaCoCo）
+   - Maven Central 发布
+   - Git Hooks（提交规范）
+   - AI 技能集成（Claude Code / Copilot / OpenCode）
+
+### 第二步：推荐插件组合
+
+根据用户的选择，从以下插件菜单推荐：
+
+| 插件 ID | 功能 | 适用场景 |
+|---------|------|----------|
+| `pub.ihub.plugin.ihub-settings` | 自动聚合子项目、仓库配置 | **所有项目必选** |
+| `pub.ihub.plugin` | 基础插件、仓库 | **所有项目必选** |
+| `pub.ihub.plugin.ihub-bom` | 依赖管理 BOM | 多模块项目推荐 |
+| `pub.ihub.plugin.ihub-java` | Java 工程配置 | Java 项目 |
+| `pub.ihub.plugin.ihub-groovy` | Groovy 工程配置 | Groovy 项目 |
+| `pub.ihub.plugin.ihub-kotlin` | Kotlin 工程配置 | Kotlin 项目 |
+| `pub.ihub.plugin.ihub-boot` | Spring Boot 集成 | Spring Boot 项目 |
+| `pub.ihub.plugin.ihub-test` | 测试任务配置 | 需要测试的项目 |
+| `pub.ihub.plugin.ihub-verification` | CodeNarc/PMD/JaCoCo | 需要质量检查的项目 |
+| `pub.ihub.plugin.ihub-publish` | 发布到 Maven Central | 需要发布的项目 |
+| `pub.ihub.plugin.ihub-git-hooks` | Git Hooks 自动化 | 需要提交规范的项目 |
+| `pub.ihub.plugin.ihub-skills` | AI 技能集成 | 使用 AI 工具的项目 |
+
+### 第三步：生成配置代码
+
+根据推荐，生成如下完整配置：
+
+#### settings.gradle.kts 示例
+
+```kotlin
+plugins {
+    id("pub.ihub.plugin.ihub-settings") version "1.9.5"
+}
+
+// iHubSettings 支持自动扫描子项目，一般无需额外配置
+```
+
+#### build.gradle.kts 示例（Java + Spring Boot 项目）
+
+```kotlin
+plugins {
+    id("pub.ihub.plugin")
+    id("pub.ihub.plugin.ihub-java")
+    id("pub.ihub.plugin.ihub-boot")
+    id("pub.ihub.plugin.ihub-test")
+    id("pub.ihub.plugin.ihub-verification")
+    id("pub.ihub.plugin.ihub-git-hooks")
+    id("pub.ihub.plugin.ihub-skills")
+}
+
+// Java 配置
+iHubJava {
+    // 可选：指定 Java 版本（默认 17）
+    // compatibility.set(JavaVersion.VERSION_21)
+}
+
+// Git Hooks 配置（可选，默认启用 conventional commit 规范）
+iHubGitHooks {
+    hooks = mapOf(
+        "pre-commit" to "./gradlew check -x test spotlessCheck",
+        "commit-msg" to "./gradlew commitCheck"
+    )
+}
+
+// AI 技能配置（可选，默认安装全部）
+iHubSkills {
+    // copilotEnabled.set(false)   // 不需要 Copilot 技能时关闭
+}
+```
+
+### 第四步：说明关键配置项
+
+为用户解释生成配置中每个关键部分的作用：
+
+1. **Property 优先级**（从高到低）：
+   - `-DiHub.xxx=value`（命令行系统属性）
+   - `IHUB_XXX=value`（环境变量）
+   - `gradle.properties`
+   - `@IHubProperty(defaultValue = ...)` 默认值
+
+2. **版本管理**：
+   - 所有依赖版本应在 `gradle/libs.versions.toml` 中统一管理
+   - 不要在各模块 `build.gradle.kts` 中硬编码版本号
+
+3. **最佳实践提醒**：
+   - ✅ 使用 `tasks.register()` 而非 `tasks.create()`
+   - ✅ 使用 `layout.buildDirectory` 而非 `buildDir`
+   - ✅ 使用 `ListProperty<T>` 而非 `Property<List<T>>`
+   - ❌ 避免 `afterEvaluate`，改用 `Provider.map()`
+
+### 参考资源
+
+- IHub 文档：https://doc.ihub.pub/plugins/
+- 版本兼容表：https://github.com/ihub-pub/plugins#readme
+- Gradle 最佳实践：https://docs.gradle.org/current/userguide/authoring_maintainable_build_scripts.html

--- a/ihub-skills/src/main/resources/META-INF/ihub/skills/claude/ihub-diagnose.md
+++ b/ihub-skills/src/main/resources/META-INF/ihub/skills/claude/ihub-diagnose.md
@@ -1,0 +1,81 @@
+---
+description: 诊断当前 Gradle 项目中与 IHub Plugins 相关的构建问题，识别反模式、版本兼容性问题，并提供具体修复建议。当用户遇到 Gradle 构建报错、任务失败或配置异常时使用。
+---
+
+你是 IHub Plugins 专家，专注于诊断 Gradle 构建问题。当前项目使用了 `pub.ihub.plugin` 系列插件。
+
+## 诊断流程
+
+请按以下步骤系统地分析项目：
+
+### 1. 收集构建信息
+
+```bash
+# 查看项目结构与 Gradle 版本
+cat settings.gradle.kts 2>/dev/null || cat settings.gradle 2>/dev/null
+./gradlew --version
+
+# 查看依赖版本目录
+cat gradle/libs.versions.toml 2>/dev/null | head -80
+```
+
+### 2. 检查常见反模式
+
+**❌ 已弃用的 Gradle API（必须逐一检查）**
+```bash
+grep -rn "tasks\.create\b" --include="*.groovy" --include="*.kts" .
+grep -rn "tasks\.getByName\b" --include="*.groovy" --include="*.kts" .
+grep -rn "\bbuildDir\b" --include="*.groovy" --include="*.kts" .
+grep -rn "afterEvaluate" --include="*.groovy" --include="*.kts" .
+grep -rn "allprojects\|subprojects" build.gradle.kts 2>/dev/null
+```
+
+**❌ 错误的 Property 类型**
+```bash
+grep -rn "Property<List\|Property<Map\|Property<File\|Property<Set" --include="*.groovy" --include="*.kt" .
+```
+
+### 3. 版本兼容性速查
+
+| IHub 版本 | JDK | Gradle |
+|-----------|-----|--------|
+| 1.9.4+    | 17~25 | 9.3.1+ |
+| 1.9.3     | 17~25 | 9.3.1  |
+| 1.9.0     | 17~24 | 9.0.0  |
+| 1.7.6+    | 17~23 | 8.13   |
+
+### 4. 常见错误速查
+
+| 症状 | 原因 | 修复 |
+|------|------|------|
+| `Cannot serialize object of type Project` | Task 执行体捕获了 Project | 改用 `@Input`/`@InputFile` 声明属性 |
+| `buildDir is deprecated` | 使用了旧 API | 改为 `layout.buildDirectory` |
+| `tasks.create() is deprecated` | 使用了旧 API | 改为 `tasks.register()` |
+| `Property<List<T>>` 警告 | 错误 Property 类型 | 改为 `ListProperty<T>` |
+| `afterEvaluate` CC 报错 | 不兼容 CC | 改为 `Provider.map()` 或 `withExtension(AFTER)` |
+| BOM 依赖冲突 | 版本未对齐 | 在 `gradle/libs.versions.toml` 统一管理 |
+
+### 5. 输出诊断报告
+
+```
+## IHub 构建诊断报告
+
+### ✅ 通过项
+- ...
+
+### ❌ 发现问题
+
+#### 问题 1：[问题名称]
+**位置**: 文件:行号
+**修复**:
+// 修改前
+...
+// 修改后
+...
+
+### 📚 参考
+- IHub 文档: https://doc.ihub.pub/plugins/
+- Gradle 升级指南: https://docs.gradle.org/current/userguide/upgrading_version_9.html
+```
+
+修复后请运行 `./gradlew check -x test` 确认无静态分析警告。

--- a/ihub-skills/src/main/resources/META-INF/ihub/skills/copilot-instructions.md
+++ b/ihub-skills/src/main/resources/META-INF/ihub/skills/copilot-instructions.md
@@ -1,0 +1,69 @@
+# IHub Plugins - GitHub Copilot Instructions
+
+This project uses the `pub.ihub.plugin` suite of Gradle plugins. When helping with this codebase, please follow these guidelines:
+
+## Plugin Overview
+
+| Plugin ID | Module | Purpose |
+|-----------|--------|---------|
+| `pub.ihub.plugin.ihub-settings` | ihub-settings | Settings plugin, auto-aggregates subprojects |
+| `pub.ihub.plugin` | ihub-plugins | Base plugin, repositories and extensions |
+| `pub.ihub.plugin.ihub-bom` | ihub-bom | BOM dependency management |
+| `pub.ihub.plugin.ihub-java` | ihub-java | Java project configuration |
+| `pub.ihub.plugin.ihub-groovy` | ihub-groovy | Groovy project configuration |
+| `pub.ihub.plugin.ihub-kotlin` | ihub-kotlin | Kotlin project configuration |
+| `pub.ihub.plugin.ihub-boot` | ihub-spring | Spring Boot integration |
+| `pub.ihub.plugin.ihub-test` | ihub-verification | Test task configuration |
+| `pub.ihub.plugin.ihub-verification` | ihub-verification | CodeNarc/PMD/JaCoCo |
+| `pub.ihub.plugin.ihub-publish` | ihub-publish | Publish to Maven Central |
+| `pub.ihub.plugin.ihub-git-hooks` | ihub-githooks | Git hooks automation |
+| `pub.ihub.plugin.ihub-skills` | ihub-skills | AI skills integration |
+
+## Gradle API Rules (IMPORTANT)
+
+**Always use modern APIs:**
+
+| ❌ Legacy (Forbidden) | ✅ Modern (Required) |
+|----------------------|---------------------|
+| `tasks.create('name')` | `tasks.register('name')` |
+| `tasks.getByName('name')` | `tasks.named('name')` |
+| `buildDir` | `layout.buildDirectory` |
+| `Property<List<T>>` | `ListProperty<T>` |
+| `Property<Map<K,V>>` | `MapProperty<K,V>` |
+| `Property<File>` (file) | `RegularFileProperty` |
+| `Property<File>` (dir) | `DirectoryProperty` |
+| `afterEvaluate {}` | `Provider.map()` / `configureEach()` |
+| `allprojects {}` / `subprojects {}` | buildSrc convention plugins |
+
+## Dependency Management
+
+- All dependency versions **must** be declared in `gradle/libs.versions.toml`
+- Reference them via `libs.xxx` in submodule build scripts
+- Never hardcode versions directly in `build.gradle.kts` files
+
+## Property Priority (High to Low)
+
+1. `-DiHub.property=value` (system property)
+2. `IHUB_PROPERTY=value` (environment variable)
+3. `gradle.properties` / `-Pproperty=value`
+4. `@IHubProperty(defaultValue = ...)` default value
+
+## Configuration Cache Compatibility
+
+- Task action bodies must NOT capture `Project` references
+- Use `@Input` / `@InputFile` / `@OutputFile` annotations for task properties
+- External commands must use `ValueSource` pattern
+- Test with `--configuration-cache` flag
+
+## Common Fixes
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `Cannot serialize object of type Project` | Task captured Project | Use `@Input` annotations instead |
+| `buildDir is deprecated` | Old API | Use `layout.buildDirectory` |
+| BOM dependency conflict | Version misalignment | Manage in `gradle/libs.versions.toml` |
+
+## Reference
+
+- IHub Plugins Documentation: https://doc.ihub.pub/plugins/
+- Version Compatibility: https://github.com/ihub-pub/plugins#readme

--- a/ihub-skills/src/test/groovy/pub/ihub/plugin/skills/IHubSkillsPluginTest.groovy
+++ b/ihub-skills/src/test/groovy/pub/ihub/plugin/skills/IHubSkillsPluginTest.groovy
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2021-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package pub.ihub.plugin.skills
+
+import pub.ihub.plugin.test.IHubSpecification
+import spock.lang.Title
+
+/**
+ * IHub AI Skills 插件测试套件
+ * @author henry
+ */
+@Title('IHub Skills 插件测试套件')
+class IHubSkillsPluginTest extends IHubSpecification {
+
+    @Override
+    def setup() {
+        buildFile << '''
+            plugins {
+                id 'pub.ihub.plugin.ihub-skills'
+            }
+        '''
+    }
+
+    def '默认配置测试：全部技能文件均被安装'() {
+        when: '执行默认构建'
+        def result = gradleBuilder.build()
+
+        then: '三个技能文件均已生成'
+        result.output.contains 'BUILD SUCCESSFUL'
+        new File(testProjectDir, '.claude/commands/ihub-diagnose.md').exists()
+        new File(testProjectDir, '.claude/commands/ihub-configure.md').exists()
+        new File(testProjectDir, '.github/copilot-instructions.md').exists()
+        new File(testProjectDir, 'AGENTS.md').exists()
+    }
+
+    def '日志测试：包含技能安装路径'() {
+        when: '执行构建'
+        def result = gradleBuilder.build()
+
+        then: '日志包含安装信息'
+        result.output.contains 'IHub Skills: installed Claude skill /ihub-diagnose'
+        result.output.contains 'IHub Skills: installed Claude skill /ihub-configure'
+        result.output.contains 'IHub Skills: installed Copilot instructions'
+        result.output.contains 'IHub Skills: installed OpenCode AGENTS.md'
+    }
+
+    def '全局禁用测试：不安装任何技能文件'() {
+        given: '配置全局禁用'
+        buildFile << '''
+            iHubSkills {
+                enabled = false
+            }
+        '''
+
+        when: '执行构建'
+        def result = gradleBuilder.build()
+
+        then: '无技能文件生成'
+        result.output.contains 'BUILD SUCCESSFUL'
+        !new File(testProjectDir, '.claude/commands/ihub-diagnose.md').exists()
+        !new File(testProjectDir, '.github/copilot-instructions.md').exists()
+        !new File(testProjectDir, 'AGENTS.md').exists()
+    }
+
+    def '单独禁用Claude技能测试'() {
+        given: '配置 Claude 技能禁用'
+        buildFile << '''
+            iHubSkills {
+                claudeEnabled = false
+            }
+        '''
+
+        when: '执行构建'
+        def result = gradleBuilder.build()
+
+        then: 'Claude 技能不安装，其他技能正常安装'
+        result.output.contains 'BUILD SUCCESSFUL'
+        !new File(testProjectDir, '.claude/commands/ihub-diagnose.md').exists()
+        new File(testProjectDir, '.github/copilot-instructions.md').exists()
+        new File(testProjectDir, 'AGENTS.md').exists()
+    }
+
+    def '单独禁用Copilot技能测试'() {
+        given: '配置 Copilot 技能禁用'
+        buildFile << '''
+            iHubSkills {
+                copilotEnabled = false
+            }
+        '''
+
+        when: '执行构建'
+        def result = gradleBuilder.build()
+
+        then: 'Copilot 技能不安装，其他技能正常安装'
+        result.output.contains 'BUILD SUCCESSFUL'
+        new File(testProjectDir, '.claude/commands/ihub-diagnose.md').exists()
+        !new File(testProjectDir, '.github/copilot-instructions.md').exists()
+        new File(testProjectDir, 'AGENTS.md').exists()
+    }
+
+    def '单独禁用OpenCode技能测试'() {
+        given: '配置 OpenCode 技能禁用'
+        buildFile << '''
+            iHubSkills {
+                openCodeEnabled = false
+            }
+        '''
+
+        when: '执行构建'
+        def result = gradleBuilder.build()
+
+        then: 'OpenCode 技能不安装，其他技能正常安装'
+        result.output.contains 'BUILD SUCCESSFUL'
+        new File(testProjectDir, '.claude/commands/ihub-diagnose.md').exists()
+        new File(testProjectDir, '.github/copilot-instructions.md').exists()
+        !new File(testProjectDir, 'AGENTS.md').exists()
+    }
+
+    def '自定义claudeCommands目录测试'() {
+        given: '配置自定义目录'
+        buildFile << '''
+            iHubSkills {
+                claudeCommandsDir = layout.projectDirectory.dir('custom-ai/commands')
+            }
+        '''
+
+        when: '执行构建'
+        def result = gradleBuilder.build()
+
+        then: '技能文件写入自定义目录'
+        result.output.contains 'BUILD SUCCESSFUL'
+        new File(testProjectDir, 'custom-ai/commands/ihub-diagnose.md').exists()
+        new File(testProjectDir, 'custom-ai/commands/ihub-configure.md').exists()
+    }
+
+    def 'claude技能文件内容测试：包含关键指令'() {
+        when: '执行构建'
+        gradleBuilder.build()
+
+        then: 'ihub-diagnose.md 包含诊断关键词'
+        def diagnoseFile = new File(testProjectDir, '.claude/commands/ihub-diagnose.md')
+        diagnoseFile.exists()
+        diagnoseFile.text.contains('IHub Plugins')
+        diagnoseFile.text.contains('tasks.create')
+        diagnoseFile.text.contains('afterEvaluate')
+
+        and: 'ihub-configure.md 包含配置向导关键词'
+        def configureFile = new File(testProjectDir, '.claude/commands/ihub-configure.md')
+        configureFile.exists()
+        configureFile.text.contains('ihub-settings')
+        configureFile.text.contains('pub.ihub.plugin')
+    }
+
+}


### PR DESCRIPTION
添加ihub-skills插件用于自动安装Claude Code、GitHub Copilot和OpenCode的AI技能文件 包含相关文档、测试用例及扩展配置功能