### PR TITLE
feat(meta): 新增 ihub-meta AI 元数据生成插件

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,8 @@ plugins/
 ├── ihub-publish/           # 发布插件：ihub-publish
 ├── ihub-shadow/            # Shadow Fat JAR：ihub-shadow
 ├── ihub-javaagent/         # Javaagent 插件：ihub-javaagent
+├── ihub-meta/              # AI 元数据 JSON 生成：ihub-meta
+├── ihub-skills/            # AI 技能文件自动安装：ihub-skills
 ├── ihub-copyright/         # Spotless 版权头：ihub-copyright
 ├── ihub-githooks/          # Git Hooks 自动化：ihub-git-hooks
 ├── ihub-node/              # Node.js / cnpm 支持：ihub-node
@@ -65,6 +67,8 @@ plugins/
 | `pub.ihub.plugin.ihub-copyright` | ihub-copyright | Spotless 版权头管理 |
 | `pub.ihub.plugin.ihub-git-hooks` | ihub-githooks | Git hooks 配置 |
 | `pub.ihub.plugin.ihub-node` | ihub-node | Node.js / cnpm 支持 |
+| `pub.ihub.plugin.ihub-skills` | ihub-skills | AI 技能文件自动安装（Claude Code / Copilot / OpenCode） |
+| `pub.ihub.plugin.ihub-meta` | ihub-meta | 项目结构元数据 JSON 生成，供 LLM/AI 工具使用 |
 
 ## VERSION COMPATIBILITY
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ IHub 提供了丰富的插件生态，按功能可分为以下几类：
 | [`pub.ihub.plugin.ihub-git-hooks`](https://doc.ihub.pub/plugins/list/iHubGitHooks) | GitHooks | Project | Git 钩子 (Hooks) 自动化配置 |
 | [`pub.ihub.plugin.ihub-node`](https://doc.ihub.pub/plugins/list/iHubNode) | Node.js | Project | Node.js 及 cnpm 运行支持 |
 | [`pub.ihub.plugin.ihub-skills`](https://doc.ihub.pub/plugins/list/iHubSkills) | Skills | Project | AI 技能文件自动安装（Claude Code / Copilot / OpenCode） |
+| [`pub.ihub.plugin.ihub-meta`](https://doc.ihub.pub/plugins/list/iHubMeta) | Meta | Project | 项目结构元数据 JSON 生成，供 LLM/AI 工具使用 |
 
 ## 🚀 快速开始 (Quick Start)
 
@@ -225,6 +226,7 @@ plugins/
 ├── ihub-githooks/          # Git Hooks 自动化插件
 ├── ihub-node/              # Node.js 插件
 ├── ihub-javaagent/         # Javaagent 插件
+├── ihub-meta/              # AI 元数据 JSON 生成插件
 ├── ihub-skills/            # AI 技能文件自动安装插件
 ├── samples/                # 示例项目
 └── docs/                   # VuePress 文档站点

--- a/docs/list/iHubMeta.md
+++ b/docs/list/iHubMeta.md
@@ -1,0 +1,90 @@
+# ihub-meta
+
+::: info 插件信息
+- `ihub-meta`插件用于生成项目结构元数据 JSON 文件，供 LLM/AI 开发工具读取并理解项目结构。
+- 当项目应用此插件后，运行 `./gradlew iHubMeta` 即可在 `build/ihub/project-meta.json` 生成项目元数据。
+:::
+
+| 插件ID | 插件名称 | 插件类型 | 扩展名称 |
+|-------|---------|--------|---------|
+| `pub.ihub.plugin.ihub-meta` | `IHub Meta插件` | `Project`[^Project] | `iHubMeta` |
+
+::: tip 输出内容
+生成的 `project-meta.json` 包含以下信息：
+- **project** — 项目名称、group、版本、描述、根目录
+- **gradle** — Gradle 版本、已应用插件列表
+- **sourceSets** — 源码目录结构（main/test，支持 Java/Groovy/Kotlin/Resources）
+- **dependencies** — 依赖信息（implementation、testImplementation 等）
+- **modules** — 子项目/模块列表
+:::
+
+## 快速开始
+
+::: tip 推荐：通过版本目录别名引用
+当项目已应用 `pub.ihub.plugin.ihub-settings` 后，IHub 会自动注册 `ihub` 版本目录，所有插件均可通过 `ihub.plugins.*` 别名引用，无需手动指定版本：
+
+```kotlin
+// settings.gradle.kts
+plugins {
+    id("pub.ihub.plugin.ihub-settings") version "1.9.5"
+}
+
+// build.gradle.kts
+plugins {
+    alias(ihub.plugins.meta)  // 等价于 id("pub.ihub.plugin.ihub-meta")
+}
+```
+
+版本目录别名规则：`pub.ihub.plugin.ihub-<name>` → `ihub.plugins.<name>`（例：`ihub-meta` → `ihub.plugins.meta`）。
+:::
+
+若不使用版本目录，也可直接声明插件 ID：
+
+```kotlin
+plugins {
+    id("pub.ihub.plugin.ihub-meta") version "1.9.5"
+}
+```
+
+应用插件后，运行 `./gradlew iHubMeta` 生成元数据 JSON。
+
+## 扩展属性
+
+| Extension | Description | Default | Ext[^Ext] | Prj[^Prj] | Sys[^Sys] | Env[^Env] |
+| --------- | ----------- | ------- | --- | --- | --- | --- |
+| `enabled` | 是否启用元数据生成 | `true` | ✔ | ✔ | ✔ | ❌ |
+| `outputFile` | JSON 输出文件路径 | `{buildDir}/ihub/project-meta.json` | ✔ | ❌ | ❌ | ❌ |
+| `includeDependencies` | 是否包含依赖信息 | `true` | ✔ | ✔ | ✔ | ❌ |
+| `includeSourceSets` | 是否包含源码目录信息 | `true` | ✔ | ✔ | ✔ | ❌ |
+
+## 示例配置
+
+### 禁用依赖信息收集
+
+```kotlin
+iHubMeta {
+    includeDependencies.set(false)
+}
+```
+
+### 自定义输出路径
+
+```kotlin
+iHubMeta {
+    outputFile.set(layout.buildDirectory.file("custom/ai-meta.json"))
+}
+```
+
+### 完全禁用
+
+```kotlin
+iHubMeta {
+    enabled.set(false)
+}
+```
+
+[^Project]: Project插件
+[^Ext]: 支持扩展属性配置
+[^Prj]: 支持项目属性配置（`gradle.properties`）
+[^Sys]: 支持系统属性配置（`-DiHub.xxx=value`）
+[^Env]: 支持环境变量配置

--- a/ihub-meta/build.gradle.kts
+++ b/ihub-meta/build.gradle.kts
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2021-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+plugins {
+    id("ihub.module-conventions")
+    id("pub.ihub.plugin.ihub-groovy")
+    id("pub.ihub.plugin.ihub-test")
+    id("pub.ihub.plugin.ihub-verification")
+    id("pub.ihub.plugin.ihub-publish")
+}
+
+description = "IHub AI Metadata Gradle Plugin"
+
+gradlePlugin {
+    plugins {
+        create("iHubMeta") {
+            id = "pub.ihub.plugin.ihub-meta"
+            displayName = "IHub Meta"
+            description = "IHub AI Metadata Gradle Plugin - Generates project structure JSON for LLM consumption"
+            implementationClass = "pub.ihub.plugin.meta.IHubMetaPlugin"
+            tags.set(listOf("ihub", "ai", "meta", "json", "llm"))
+        }
+    }
+}

--- a/ihub-meta/gradle.properties
+++ b/ihub-meta/gradle.properties
@@ -1,0 +1,1 @@
+iHubVerification.jacocoBranchCoverageRuleEnabled=false

--- a/ihub-meta/src/main/groovy/pub/ihub/plugin/meta/IHubMetaExtension.groovy
+++ b/ihub-meta/src/main/groovy/pub/ihub/plugin/meta/IHubMetaExtension.groovy
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2021-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package pub.ihub.plugin.meta
+
+import groovy.transform.CompileStatic
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Property
+
+import javax.inject.Inject
+
+/**
+ * IHub AI Metadata 插件扩展，控制项目元数据 JSON 的生成行为。
+ *
+ * @author henry
+ */
+@CompileStatic
+class IHubMetaExtension {
+
+    /**
+     * 是否启用元数据生成（默认开启）
+     */
+    final Property<Boolean> enabled
+
+    /**
+     * JSON 输出文件（默认：{buildDir}/ihub/project-meta.json）
+     */
+    final RegularFileProperty outputFile
+
+    /**
+     * 是否包含依赖信息（默认开启）
+     */
+    final Property<Boolean> includeDependencies
+
+    /**
+     * 是否包含 SourceSet 信息（默认开启）
+     */
+    final Property<Boolean> includeSourceSets
+
+    @Inject
+    IHubMetaExtension(ObjectFactory objects) {
+        enabled = objects.property(Boolean).convention(true)
+        outputFile = objects.fileProperty()
+        includeDependencies = objects.property(Boolean).convention(true)
+        includeSourceSets = objects.property(Boolean).convention(true)
+    }
+
+}
+

--- a/ihub-meta/src/main/groovy/pub/ihub/plugin/meta/IHubMetaPlugin.groovy
+++ b/ihub-meta/src/main/groovy/pub/ihub/plugin/meta/IHubMetaPlugin.groovy
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2021-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package pub.ihub.plugin.meta
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+/**
+ * IHub AI Metadata 插件
+ * 当项目应用此插件后，可使用 {@code ./gradlew iHubMeta} 生成项目结构 JSON 文件，
+ * 供 LLM / AI 开发工具读取并理解项目结构。
+ *
+ * <h4>基本用法</h4>
+ * <pre>{@code
+ * plugins {
+ *     id("pub.ihub.plugin.ihub-meta")
+ * }
+ * }</pre>
+ *
+ * <h4>自定义配置</h4>
+ * <pre>{@code
+ * iHubMeta {
+ *     includeDependencies.set(false)
+ *     outputFile.set(layout.buildDirectory.file("custom-meta.json"))
+ * }
+ * }</pre>
+ *
+ * @author henry
+ */
+class IHubMetaPlugin implements Plugin<Project> {
+
+    static final String EXTENSION_NAME = 'iHubMeta'
+    static final String TASK_GROUP = 'ihub'
+    static final String TASK_NAME = 'iHubMeta'
+
+    @Override
+    void apply(Project project) {
+        IHubMetaExtension ext = project.extensions.create(EXTENSION_NAME, IHubMetaExtension)
+
+        ext.outputFile.convention(
+            project.layout.buildDirectory.file('ihub/project-meta.json')
+        )
+
+        project.tasks.register(TASK_NAME, IHubMetaTask) { IHubMetaTask task ->
+            task.group = TASK_GROUP
+            task.description = 'Generate project structure metadata JSON for AI/LLM consumption.'
+            task.outputFile.set(ext.outputFile)
+            task.metaEnabled.set(ext.enabled)
+            task.includeDependencies.set(ext.includeDependencies)
+            task.includeSourceSets.set(ext.includeSourceSets)
+        }
+    }
+
+}

--- a/ihub-meta/src/main/groovy/pub/ihub/plugin/meta/IHubMetaTask.groovy
+++ b/ihub-meta/src/main/groovy/pub/ihub/plugin/meta/IHubMetaTask.groovy
@@ -1,0 +1,221 @@
+/*
+ * Copyright (c) 2021-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package pub.ihub.plugin.meta
+
+import groovy.json.JsonBuilder
+import org.gradle.api.DefaultTask
+import org.gradle.api.Project
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
+
+/**
+ * IHub AI Metadata 生成任务
+ * 收集当前 Gradle 项目及全部子项目（modules）的结构信息，
+ * 输出为 build/ihub/project-meta.json，供 LLM / AI 工具读取。
+ *
+ * @author henry
+ */
+@DisableCachingByDefault(because = '元数据内容依赖项目源代码结构变化，不适合构建缓存')
+@SuppressWarnings('AbstractClassWithoutAbstractMethod')
+abstract class IHubMetaTask extends DefaultTask {
+
+    @OutputFile
+    abstract RegularFileProperty getOutputFile()
+
+    @Input
+    abstract Property<Boolean> getMetaEnabled()
+
+    @Input
+    abstract Property<Boolean> getIncludeDependencies()
+
+    @Input
+    abstract Property<Boolean> getIncludeSourceSets()
+
+    @TaskAction
+    void generate() {
+        if (!metaEnabled.get()) {
+            logger.lifecycle('IHub Meta: metadata generation is disabled, skipping.')
+            return
+        }
+
+        Project rootProject = project.rootProject
+        Map<String, Object> meta = [:]
+
+        meta.project = collectProjectInfo(rootProject)
+        meta.gradle = collectGradleInfo(rootProject)
+
+        if (includeSourceSets.get()) {
+            meta.sourceSets = collectSourceSets(rootProject)
+        }
+
+        if (includeDependencies.get()) {
+            meta.dependencies = collectDependencies(rootProject)
+        }
+
+        meta.modules = collectModules(rootProject)
+
+        File outFile = outputFile.get().asFile
+        outFile.parentFile.mkdirs()
+        outFile.write new JsonBuilder(meta).toPrettyString()
+
+        logger.lifecycle('IHub Meta: project metadata written to {}', outFile)
+    }
+
+    private Map<String, Object> collectProjectInfo(Project project) {
+        [
+            name       : project.name,
+            group      : project.group.toString(),
+            version    : project.version.toString(),
+            description: project.description ?: null,
+            rootDir    : project.projectDir.absolutePath,
+        ]
+    }
+
+    private Map<String, Object> collectGradleInfo(Project project) {
+        [
+            version: project.gradle.gradleVersion,
+            plugins: collectAppliedPlugins(project),
+        ]
+    }
+
+    private List<Map<String, String>> collectAppliedPlugins(Project project) {
+        List<String> candidateIds = [
+            'java', 'groovy', 'kotlin', 'java-library', 'application', 'war',
+            'maven-publish', 'ivy-publish', 'signing',
+            'checkstyle', 'pmd', 'idea', 'eclipse',
+            'distribution', 'platform-base', 'reporting-base',
+            'pub.ihub.plugin.ihub-java', 'pub.ihub.plugin.ihub-groovy',
+            'pub.ihub.plugin.ihub-kotlin', 'pub.ihub.plugin.ihub-boot',
+            'pub.ihub.plugin.ihub-native', 'pub.ihub.plugin.ihub-node',
+            'pub.ihub.plugin.ihub-publish', 'pub.ihub.plugin.ihub-javaagent',
+            'pub.ihub.plugin.ihub-shadow', 'pub.ihub.plugin.ihub-copyright',
+            'pub.ihub.plugin.ihub-git-hooks', 'pub.ihub.plugin.ihub-settings',
+            'pub.ihub.plugin.ihub-bom', 'pub.ihub.plugin.ihub-verification',
+            'pub.ihub.plugin.ihub-test', 'pub.ihub.plugin.ihub-skills',
+            'pub.ihub.plugin.ihub-meta', 'pub.ihub.plugin.ihub-base',
+            'pub.ihub.plugin.ihub-java-base',
+            'pub.ihub.plugin', 'pub.ihub.plugin.ihub-profiles',
+            'pub.ihub.plugin.ihub-version',
+            'org.springframework.boot',
+            'io.spring.dependency-management',
+            'org.springframework.cloud.contract',
+            'com.gradle.plugin-publish',
+            'com.diffplug.spotless',
+            'com.github.ben-manes.versions',
+            'org.jetbrains.kotlin.jvm',
+            'org.jetbrains.kotlin.plugin.spring',
+            'com.github.johnrengelman.shadow',
+        ]
+
+        List<Map<String, String>> result = []
+        for (String id : candidateIds) {
+            if (project.pluginManager.hasPlugin(id)) {
+                result << [id: id]
+            }
+        }
+        result
+    }
+
+    private Map<String, Object> collectSourceSets(Project project) {
+        Map<String, Object> result = [:]
+        for (Project p : project.allprojects) {
+            collectSourceSetsForProject(p, project, result)
+        }
+        if (result.size() == 1 && result.containsKey(project.name)) {
+            return result.get(project.name) as Map<String, Object>
+        }
+        result
+    }
+
+    private void collectSourceSetsForProject(Project p, Project rootProject, Map<String, Object> result) {
+        if (!p.pluginManager.hasPlugin('java')) {
+            return
+        }
+        def sourceSets = p.extensions.findByName('sourceSets')
+        if (!sourceSets) {
+            return
+        }
+        Map<String, Object> projectSources = [:]
+        for (def srcSet : sourceSets) {
+            if (srcSet.name in ['main', 'test']) {
+                Map<String, List<String>> dirs = collectSourceDirsForSourceSet(srcSet)
+                if (dirs) {
+                    projectSources[srcSet.name] = dirs
+                }
+            }
+        }
+        if (projectSources) {
+            result[p == rootProject ? rootProject.name : p.path] = projectSources
+        }
+    }
+
+    private Map<String, List<String>> collectSourceDirsForSourceSet(srcSet) {
+        Map<String, List<String>> dirs = [:]
+        if (srcSet.java?.srcDirs) {
+            dirs.java = srcSet.java.srcDirs*.absolutePath as List<String>
+        }
+        if (srcSet.hasProperty('groovy') && srcSet.groovy?.srcDirs) {
+            dirs.groovy = srcSet.groovy.srcDirs*.absolutePath as List<String>
+        }
+        if (srcSet.hasProperty('kotlin') && srcSet.kotlin?.srcDirs) {
+            dirs.kotlin = srcSet.kotlin.srcDirs*.absolutePath as List<String>
+        }
+        if (srcSet.resources?.srcDirs) {
+            dirs.resources = srcSet.resources.srcDirs*.absolutePath as List<String>
+        }
+        dirs
+    }
+
+    private Map<String, Object> collectDependencies(Project project) {
+        Map<String, Object> result = [:]
+        List<String> relevantConfigs = [
+            'implementation', 'testImplementation', 'compileOnly',
+            'testCompileOnly', 'runtimeOnly', 'testRuntimeOnly',
+            'annotationProcessor', 'testAnnotationProcessor',
+            'api', 'testFixturesImplementation',
+        ]
+        for (String configName : relevantConfigs) {
+            def config = project.configurations.findByName(configName)
+            if (config) {
+                def deps = config.dependencies.findAll { it.group }
+                    .collect { "${it.group}:${it.name}:${it.version}" }
+                if (deps) {
+                    result[configName] = deps
+                }
+            }
+        }
+        result
+    }
+
+    private List<Map<String, Object>> collectModules(Project rootProject) {
+        List<Map<String, Object>> modules = []
+        rootProject.subprojects.each { Project sub ->
+            modules << [
+                name       : sub.name,
+                path       : sub.path,
+                group      : sub.group.toString(),
+                version    : sub.version.toString(),
+                description: sub.description ?: null,
+            ]
+        }
+        modules
+    }
+
+}

--- a/ihub-meta/src/test/groovy/pub/ihub/plugin/meta/IHubMetaPluginTest.groovy
+++ b/ihub-meta/src/test/groovy/pub/ihub/plugin/meta/IHubMetaPluginTest.groovy
@@ -1,0 +1,199 @@
+/*
+ * Copyright (c) 2021-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package pub.ihub.plugin.meta
+
+import groovy.json.JsonSlurper
+import pub.ihub.plugin.test.IHubSpecification
+import spock.lang.Title
+
+/**
+ * IHub AI Metadata 插件测试套件
+ * @author henry
+ */
+@Title('IHub Meta 插件测试套件')
+class IHubMetaPluginTest extends IHubSpecification {
+
+    @Override
+    def setup() {
+        buildFile << '''
+            plugins {
+                id 'pub.ihub.plugin.ihub-meta'
+            }
+        '''
+    }
+
+    def '默认配置测试：生成 project-meta.json 并包含基本字段'() {
+        when: '执行 iHubMeta 任务'
+        def result = gradleBuilder.withArguments('iHubMeta').build()
+
+        then: '构建成功，JSON 文件已生成'
+        result.output.contains 'BUILD SUCCESSFUL'
+        def jsonFile = new File(testProjectDir, 'build/ihub/project-meta.json')
+        jsonFile.exists()
+
+        and: 'JSON 包含项目元数据'
+        def json = new JsonSlurper().parse(jsonFile)
+        json.project
+        json.project.name
+        json.gradle
+        json.gradle.version
+        json.gradle.plugins.find { it.id == 'pub.ihub.plugin.ihub-meta' }
+    }
+
+    def '禁用测试：enabled=false 时不生成文件'() {
+        given: '配置禁用元数据生成'
+        buildFile << '''
+            iHubMeta {
+                enabled = false
+            }
+        '''
+
+        when: '执行 iHubMeta 任务'
+        def result = gradleBuilder.withArguments('iHubMeta').build()
+
+        then: '构建成功，但不生成 JSON 文件'
+        result.output.contains 'BUILD SUCCESSFUL'
+        result.output.contains 'metadata generation is disabled'
+        !new File(testProjectDir, 'build/ihub/project-meta.json').exists()
+    }
+
+    def '排除依赖测试：includeDependencies=false 时不包含 dependencies 字段'() {
+        given: '配置不包含依赖信息'
+        buildFile << '''
+            iHubMeta {
+                includeDependencies = false
+            }
+        '''
+
+        when: '执行 iHubMeta 任务'
+        gradleBuilder.withArguments('iHubMeta').build()
+
+        then: 'JSON 不包含 dependencies 字段'
+        def jsonFile = new File(testProjectDir, 'build/ihub/project-meta.json')
+        def json = new JsonSlurper().parse(jsonFile)
+        !json.containsKey('dependencies')
+    }
+
+    def '排除 SourceSet 测试：includeSourceSets=false 时不包含 sourceSets'() {
+        given: '配置不包含 sourceSets'
+        buildFile << '''
+            iHubMeta {
+                includeSourceSets = false
+            }
+        '''
+
+        when: '执行 iHubMeta 任务'
+        gradleBuilder.withArguments('iHubMeta').build()
+
+        then: 'JSON 不包含 sourceSets 字段'
+        def jsonFile = new File(testProjectDir, 'build/ihub/project-meta.json')
+        def json = new JsonSlurper().parse(jsonFile)
+        !json.containsKey('sourceSets')
+    }
+
+    def '自定义输出路径测试'() {
+        given: '自定义输出文件路径'
+        buildFile << '''
+            iHubMeta {
+                outputFile = layout.buildDirectory.file('custom/ai-meta.json')
+            }
+        '''
+
+        when: '执行 iHubMeta 任务'
+        gradleBuilder.withArguments('iHubMeta').build()
+
+        then: 'JSON 文件写入自定义路径'
+        def jsonFile = new File(testProjectDir, 'build/custom/ai-meta.json')
+        jsonFile.exists()
+        def json = new JsonSlurper().parse(jsonFile)
+        json.project
+    }
+
+    def '插件自包含测试：iHubMeta 出现在 applied plugins 列表中'() {
+        when: '执行 iHubMeta 任务后检查 JSON'
+        gradleBuilder.withArguments('iHubMeta').build()
+        def jsonFile = new File(testProjectDir, 'build/ihub/project-meta.json')
+        def json = new JsonSlurper().parse(jsonFile)
+
+        then: 'iHubMeta 插件出现在 applied plugins 列表中'
+        json.gradle.plugins.find { it.id == 'pub.ihub.plugin.ihub-meta' }
+    }
+
+    def '包含 Java SourceSet 信息测试'() {
+        given: '应用 Java 插件并创建源码目录'
+        buildFile << '''
+            plugins {
+                id 'java'
+            }
+        '''
+        newFolder('src/main/java')
+        newFolder('src/test/java')
+
+        when: '执行 iHubMeta 任务'
+        gradleBuilder.withArguments('iHubMeta').build()
+
+        then: 'JSON 包含 sourceSets 信息'
+        def jsonFile = new File(testProjectDir, 'build/ihub/project-meta.json')
+        def json = new JsonSlurper().parse(jsonFile)
+        json.sourceSets
+        json.sourceSets.main
+    }
+
+    def '包含依赖信息测试'() {
+        given: '应用 Java 插件并添加项目依赖'
+        buildFile << '''
+            plugins {
+                id 'java'
+            }
+            repositories {
+                mavenCentral()
+            }
+            dependencies {
+                implementation 'com.google.guava:guava:33.0.0-jre'
+            }
+        '''
+
+        when: '执行 iHubMeta 任务'
+        gradleBuilder.withArguments('iHubMeta').build()
+
+        then: 'JSON 包含依赖信息'
+        def jsonFile = new File(testProjectDir, 'build/ihub/project-meta.json')
+        def json = new JsonSlurper().parse(jsonFile)
+        json.dependencies
+    }
+
+    def '多项目测试：modules 字段包含子项目信息'() {
+        given: '创建多项目结构'
+        settingsFile << '''
+            include 'sub1'
+            include 'sub2'
+        '''
+        newFolder('sub1')
+        newFolder('sub2')
+        newFile('sub1/build.gradle')
+
+        when: '执行 iHubMeta 任务'
+        gradleBuilder.withArguments('iHubMeta').build()
+
+        then: 'JSON 包含子项目信息'
+        def jsonFile = new File(testProjectDir, 'build/ihub/project-meta.json')
+        def json = new JsonSlurper().parse(jsonFile)
+        json.modules.size() == 2
+        json.modules.find { it.name == 'sub1' && it.path == ':sub1' }
+        json.modules.find { it.name == 'sub2' && it.path == ':sub2' }
+    }
+
+}


### PR DESCRIPTION
基于 ihub-skills 模式实现，包含 Extension、Task、Plugin 三件套架构。 可通过 ./gradlew iHubMeta 生成 build/ihub/project-meta.json， 供 LLM/AI 开发工具读取项目结构、依赖、源码目录及子模块信息。