### PR TITLE
refactor: 统一插件banner打印逻辑，修复跨类加载器类型兼容问题

### DIFF
--- a/ihub-base/src/main/groovy/pub/ihub/plugin/IHubPluginMethods.groovy
+++ b/ihub-base/src/main/groovy/pub/ihub/plugin/IHubPluginMethods.groovy
@@ -66,6 +66,15 @@ final class IHubPluginMethods {
     }
 
     /**
+     * 打印Banner信息（兼容跨ClassLoader场景下GString/LinkedHashMap类型）
+     * @param title 标题（接受GString）
+     * @param info 信息键值对（接受LinkedHashMap）
+     */
+    static void printBanner(Object title, Map info) {
+        printConfigContent title.toString(), info.collect { k, v -> [k, v] } as List<List<?>>, 'Property', 'Value'
+    }
+
+    /**
      * 打印配置信息
      * @param title 标题
      * @param data 配置信息

--- a/ihub-node/src/main/groovy/pub/ihub/plugin/node/IHubNodePlugin.groovy
+++ b/ihub-node/src/main/groovy/pub/ihub/plugin/node/IHubNodePlugin.groovy
@@ -48,7 +48,7 @@ class IHubNodePlugin extends IHubProjectPluginAware<IHubNodeExtension> {
             ['OS',             "${System.getProperty('os.name')} ${System.getProperty('os.version')} (${System.getProperty('os.arch')})".toString()],
             ['CPU / Max Heap', "${Runtime.runtime.availableProcessors()} cores, ${Runtime.runtime.maxMemory() >> 20} MB".toString()],
             ['Documentation',  'https://doc.ihub.pub/plugins/iHubNode'],
-        ] as List<List<?>>, 'Property', 'Value'
+        ], 'Property', 'Value'
 
         Directory cacheDir = project.layout.projectDirectory.dir '.gradle'
         extension.workDir.set extension.workDir.getOrElse(cacheDir.dir('nodejs').asFile.path)

--- a/ihub-node/src/main/groovy/pub/ihub/plugin/node/IHubNodePlugin.groovy
+++ b/ihub-node/src/main/groovy/pub/ihub/plugin/node/IHubNodePlugin.groovy
@@ -25,7 +25,7 @@ import pub.ihub.plugin.node.cnpm.task.CnpmSetupTask
 import pub.ihub.plugin.node.cnpm.task.CnpmSyncTask
 import pub.ihub.plugin.node.cnpm.task.CnpmTask
 
-import static pub.ihub.plugin.IHubPluginMethods.printBanner
+import static pub.ihub.plugin.IHubPluginMethods.printConfigContent
 import static pub.ihub.plugin.IHubProjectPluginAware.EvaluateStage.AFTER
 
 /**
@@ -42,13 +42,13 @@ class IHubNodePlugin extends IHubProjectPluginAware<IHubNodeExtension> {
     @Override
     protected void apply() {
         String version = IHubNodePlugin.package.implementationVersion ?: 'local'
-        printBanner "IHub Node Plugin $version", [
-            'Java Version'  : "${System.getProperty('java.version')} (${System.getProperty('java.vendor')})",
-            'Gradle Version': project.gradle.gradleVersion,
-            'OS'            : "${System.getProperty('os.name')} ${System.getProperty('os.version')} (${System.getProperty('os.arch')})",
-            'CPU / Max Heap': "${Runtime.runtime.availableProcessors()} cores, ${Runtime.runtime.maxMemory() >> 20} MB",
-            'Documentation' : 'https://doc.ihub.pub/plugins/iHubNode',
-        ]
+        printConfigContent "IHub Node Plugin $version".toString(), [
+            ['Java Version',   "${System.getProperty('java.version')} (${System.getProperty('java.vendor')})".toString()],
+            ['Gradle Version', project.gradle.gradleVersion],
+            ['OS',             "${System.getProperty('os.name')} ${System.getProperty('os.version')} (${System.getProperty('os.arch')})".toString()],
+            ['CPU / Max Heap', "${Runtime.runtime.availableProcessors()} cores, ${Runtime.runtime.maxMemory() >> 20} MB".toString()],
+            ['Documentation',  'https://doc.ihub.pub/plugins/iHubNode'],
+        ] as List<List<?>>, 'Property', 'Value'
 
         Directory cacheDir = project.layout.projectDirectory.dir '.gradle'
         extension.workDir.set extension.workDir.getOrElse(cacheDir.dir('nodejs').asFile.path)

--- a/ihub-plugins/src/main/groovy/pub/ihub/plugin/IHubPluginsPlugin.groovy
+++ b/ihub-plugins/src/main/groovy/pub/ihub/plugin/IHubPluginsPlugin.groovy
@@ -19,7 +19,7 @@ import org.gradle.api.tasks.Delete
 import pub.ihub.plugin.bom.IHubBomPlugin
 import pub.ihub.plugin.version.IHubVersionPlugin
 
-import static pub.ihub.plugin.IHubPluginMethods.printBanner
+import static pub.ihub.plugin.IHubPluginMethods.printConfigContent
 import static pub.ihub.plugin.IHubPluginMethods.printLineConfigContent
 import static pub.ihub.plugin.IHubProjectPluginAware.EvaluateStage.AFTER
 
@@ -37,13 +37,13 @@ class IHubPluginsPlugin extends IHubProjectPluginAware<IHubPluginsExtension> {
 
         if (project == project.rootProject) {
             String version = IHubPluginsPlugin.package.implementationVersion ?: 'local'
-            printBanner "IHub Plugins $version", [
-                'Java Version'  : "${System.getProperty('java.version')} (${System.getProperty('java.vendor')})",
-                'Gradle Version': project.gradle.gradleVersion,
-                'OS'            : "${System.getProperty('os.name')} ${System.getProperty('os.version')} (${System.getProperty('os.arch')})",
-                'CPU / Max Heap': "${Runtime.runtime.availableProcessors()} cores, ${Runtime.runtime.maxMemory() >> 20} MB",
-                'Documentation' : 'https://doc.ihub.pub/plugins',
-            ]
+            printConfigContent "IHub Plugins $version".toString(), [
+                ['Java Version',   "${System.getProperty('java.version')} (${System.getProperty('java.vendor')})".toString()],
+                ['Gradle Version', project.gradle.gradleVersion],
+                ['OS',             "${System.getProperty('os.name')} ${System.getProperty('os.version')} (${System.getProperty('os.arch')})".toString()],
+                ['CPU / Max Heap', "${Runtime.runtime.availableProcessors()} cores, ${Runtime.runtime.maxMemory() >> 20} MB".toString()],
+                ['Documentation',  'https://doc.ihub.pub/plugins'],
+            ] as List<List<?>>, 'Property', 'Value'
             // Github Actions环境下，自动同意Scan插件条款
             if (project.hasProperty('buildScan') && System.getenv('GITHUB_ACTIONS')) {
                 project.buildScan {

--- a/ihub-plugins/src/main/groovy/pub/ihub/plugin/IHubPluginsPlugin.groovy
+++ b/ihub-plugins/src/main/groovy/pub/ihub/plugin/IHubPluginsPlugin.groovy
@@ -43,7 +43,7 @@ class IHubPluginsPlugin extends IHubProjectPluginAware<IHubPluginsExtension> {
                 ['OS',             "${System.getProperty('os.name')} ${System.getProperty('os.version')} (${System.getProperty('os.arch')})".toString()],
                 ['CPU / Max Heap', "${Runtime.runtime.availableProcessors()} cores, ${Runtime.runtime.maxMemory() >> 20} MB".toString()],
                 ['Documentation',  'https://doc.ihub.pub/plugins'],
-            ] as List<List<?>>, 'Property', 'Value'
+            ], 'Property', 'Value'
             // Github Actions环境下，自动同意Scan插件条款
             if (project.hasProperty('buildScan') && System.getenv('GITHUB_ACTIONS')) {
                 project.buildScan {


### PR DESCRIPTION
1. 新增printBanner工具方法，兼容GString和LinkedHashMap类型参数
2. 替换IHubNodePlugin和IHubPluginsPlugin中的旧banner打印代码
3. 统一将参数转换为printConfigContent支持的格式