### PR TITLE
build(deps): bump ihub-dependencies 1.7.7 -> 2.0.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-ihub = '1.7.7'
+ihub = '2.0.0'
 freefair = '9.5.0'
 spring-boot = '4.1.0'
 plugin-publish = '2.1.1'


### PR DESCRIPTION
## 升级 ihub-dependencies 至 libs 2.0.0

### 变更
- `ihub`: 1.7.7 -> 2.0.0（对齐 libs 2.0.0 AI 上下文工程正式版）

### libs 2.0.0 关键内容
- IHub 能力目录语义层（13 领域 × 39 组件 + ai_context）
- Spring AI 2.0 GA（MCP SDK 2.0，对齐 2025-11-25 规范）
- Spring Boot 4.1.0 / Spring Cloud 2025.1.2

### 兼容性
- plugins 自身 `spring-boot` 已为 4.1.0，无冲突
- 本地 `./gradlew build` 全量通过（304 tasks）

### 关联
- 依赖 libs 2.0.0 已发布: https://github.com/ihub-pub/libs/releases/tag/2.0.0
- 后续: 合并后发布 plugins 2.0.0-m2（含 #1395 Gradle 9.6.1 修复 + 本次 libs 升级）