### PR TITLE
build(shadow): 升级 shadow 8.1.1 -> com.gradleup.shadow 8.3.6

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,7 +21,7 @@ freefair-settings = { module = 'io.freefair.gradle:settings-plugin', version.ref
 ben-manes-versions = { module = 'com.github.ben-manes:gradle-versions-plugin', version = '0.54.0' }
 spotless = { module = 'com.diffplug.spotless:spotless-plugin-gradle', version = '8.10.0' }
 maven-central = { module = 'tech.yanand.gradle:maven-central-publish', version = '1.3.0' }
-shadow = { module = 'com.github.johnrengelman:shadow', version = '8.1.1' }
+shadow = { module = 'com.gradleup.shadow:shadow-gradle-plugin', version = '8.3.6' }
 javaagent = { module = 'com.ryandens:plugin', version = '0.12.2' }
 byte-buddy = { module = 'net.bytebuddy:byte-buddy-gradle-plugin', version = '1.18.12' }
 jmolecules-bytebuddy = { module = 'org.jmolecules.integrations:jmolecules-bytebuddy', version = '1.6.0' }

--- a/ihub-shadow/src/test/groovy/pub/ihub/plugin/shadow/IHubShadowPluginTest.groovy
+++ b/ihub-shadow/src/test/groovy/pub/ihub/plugin/shadow/IHubShadowPluginTest.groovy
@@ -15,9 +15,7 @@
  */
 package pub.ihub.plugin.shadow
 
-import org.gradle.testkit.runner.UnexpectedBuildFailure
 import pub.ihub.plugin.test.IHubSpecification
-import spock.lang.FailsWith
 import spock.lang.Title
 
 /**
@@ -49,7 +47,6 @@ class IHubShadowPluginTest extends IHubSpecification {
         result.output.contains 'BUILD SUCCESSFUL'
     }
 
-    @FailsWith(value = UnexpectedBuildFailure, reason = 'shadow 暂不兼容Gradle 9.0.0')
     def 'Shadow插件应用配置测试'() {
         setup: '初始化项目'
         copyProject 'basic.gradle'


### PR DESCRIPTION
## 变更概要

偿还记录已久的技术债：修复 ihub-shadow 插件在 Gradle 9 上不可用的问题。

### 背景
- shadow 8.1.1（com.github.johnrengelman）的 `ShadowCopyAction.visitDir` 访问 Gradle 9 已移除的 `details.mode` 属性，`shadowJar` 报 `MissingPropertyException`（integrations 0.2.3 发布失败的根因）
- integrations 曾被迫在 ihub-agent-trace-plugin 内联 `com.gradleup.shadow 8.3.6` 绕过（PR #351）

### 变更
- `gradle/libs.versions.toml`：`com.github.johnrengelman:shadow:8.1.1` → `com.gradleup.shadow:shadow-gradle-plugin:8.3.6`
- com.gradleup.shadow 是 shadow 官方续作（Gradle 9 兼容维护），包名保持 `com.github.jengelman.gradle.plugins.shadow`，插件源码零改动
- 移除测试过时的 `@FailsWith(UnexpectedBuildFailure, 'shadow 暂不兼容Gradle 9.0.0')`——升级后 Gradle 9.7.1 下正常构建

### 验证
- `:ihub-shadow:test` 全绿（含原 @FailsWith 用例转正常通过）
- 全量 `./gradlew build` ✓

### 后续（合并 + 发版 2.0.0-m3 后）
- integrations `ihub-agent-trace-plugin` 恢复 `alias(ihub.plugins.shadow)`（去内联）